### PR TITLE
Updating Cuckoo for Swift 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.2
+osx_image: xcode9
 xcode_project: Cuckoo.xcodeproj
 xcode_scheme: Cuckoo
 xcode_sdk: macosx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.3
+
+* Updated for Swift 4 (Xcode 9 GM)
+
 ## 0.9.2
 
 * Fixed crash when source files were using non-ASCII characters - [bug #126](https://github.com/Brightify/Cuckoo/issues/126)

--- a/Cuckoo.podspec
+++ b/Cuckoo.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Cuckoo"
-  s.version          = "0.9.2"
+  s.version          = "0.9.3"
   s.summary          = "Cuckoo - first boilerplate-free Swift mocking framework."
   s.description      = <<-DESC
                         Cuckoo is a mocking framework with an easy to use API (inspired by Mockito).

--- a/Generator/Package.resolved
+++ b/Generator/Package.resolved
@@ -1,0 +1,106 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Clang_C",
+        "repositoryURL": "https://github.com/norio-nomura/Clang_C.git",
+        "state": {
+          "branch": null,
+          "revision": "90a9574276f0fd17f02f58979423c3fd4d73b59e",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "package": "Commandant",
+        "repositoryURL": "https://github.com/Carthage/Commandant.git",
+        "state": {
+          "branch": null,
+          "revision": "c281992c31c3f41c48b5036c5a38185eaec32626",
+          "version": "0.12.0"
+        }
+      },
+      {
+        "package": "FileKit",
+        "repositoryURL": "https://github.com/TadeasKriz/FileKit.git",
+        "state": {
+          "branch": "develop",
+          "revision": "0acc6e7c336bbd2336c2f9670564dac9ec9c03fe",
+          "version": null
+        }
+      },
+      {
+        "package": "PathKit",
+        "repositoryURL": "https://github.com/kylef/PathKit.git",
+        "state": {
+          "branch": null,
+          "revision": "891a3fec2699fc43aed18b7649950677c0152a22",
+          "version": "0.8.0"
+        }
+      },
+      {
+        "package": "Result",
+        "repositoryURL": "https://github.com/antitypical/Result.git",
+        "state": {
+          "branch": null,
+          "revision": "c8446185238659a2b27c0261f64ff1254291d07d",
+          "version": "3.2.3"
+        }
+      },
+      {
+        "package": "SWXMLHash",
+        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
+        "state": {
+          "branch": null,
+          "revision": "88095d2bb1d2deb9ea9d9963737871049b21e1b4",
+          "version": "4.2.1"
+        }
+      },
+      {
+        "package": "SourceKit",
+        "repositoryURL": "https://github.com/norio-nomura/SourceKit.git",
+        "state": {
+          "branch": null,
+          "revision": "18eaa67ca44443bbe39646916792b9f0c98dbaa1",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "package": "SourceKitten",
+        "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
+        "state": {
+          "branch": null,
+          "revision": "7c4c6d8194389493f841b75fafa8c29b274c7ea6",
+          "version": "0.18.1"
+        }
+      },
+      {
+        "package": "Spectre",
+        "repositoryURL": "https://github.com/kylef/Spectre.git",
+        "state": {
+          "branch": null,
+          "revision": "e46b75cf03ad5e563b4b0a5068d3d6f04d77d80b",
+          "version": "0.7.2"
+        }
+      },
+      {
+        "package": "Stencil",
+        "repositoryURL": "https://github.com/kylef/Stencil.git",
+        "state": {
+          "branch": null,
+          "revision": "65a461d0a103896c8ff7e3f17f7be1a5badadeb0",
+          "version": "0.9.0"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "5ac9248b378b5e12201c255ba74caf990d1e0f4b",
+          "version": "0.3.6"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Generator/Package@swift-4.swift
+++ b/Generator/Package@swift-4.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "CuckooGenerator",
+    products: [
+        .executable(name: "TemplateEncoder", targets: ["TemplateEncoder", "CuckooGeneratorFramework"]),
+        .library(name: "CuckooGeneratorFramework", targets:["CuckooGeneratorFramework", "cuckoo_generator"]),
+        .executable(name: "cuckoo_generator", targets: ["cuckoo_generator"])
+        
+    ],
+    dependencies: [
+        .package(url: "https://github.com/jpsim/SourceKitten.git", .upToNextMinor(from: "0.18.1")),
+        .package(url: "https://github.com/TadeasKriz/FileKit.git", .branch("develop")),
+        .package(url: "https://github.com/kylef/Stencil.git", from: "0.9.0"),
+        .package(url: "https://github.com/Carthage/Commandant.git", from: "0.12.0")
+        ],
+    targets: [
+        .target(name: "TemplateEncoder", exclude: ["Tests"]),
+        
+        .target(name: "CuckooGeneratorFramework", dependencies: [
+            .target(name: "TemplateEncoder"), "FileKit", "SourceKittenFramework", "Stencil", "Commandant"], exclude: ["Tests"]),
+        
+        .target(name: "cuckoo_generator", dependencies: [
+            .target(name: "CuckooGeneratorFramework")], exclude: ["Tests"]),
+        ]
+)
+

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -106,11 +106,11 @@ public struct Tokenizer {
 
         case Kinds.InstanceVariable.rawValue:
             let setterAccessibility = (dictionary[Key.SetterAccessibility.rawValue] as? String).flatMap(Accessibility.init)
-
-            if String(describing: source.utf8.dropFirst(range!.startIndex)).takeUntil(occurence: name)?.trimmed.hasPrefix("let") == true {
-                return nil
+                        
+            if String.init(source.utf8.dropFirst(range!.startIndex))?.takeUntil(occurence: name)?.trimmed.hasPrefix("let") == true {
+                    return nil
             }
-
+            
             if type == nil {
                 stderrPrint("Type of instance variable \(name) could not be inferred. Please specify it explicitly. (\(file.path ?? ""))")
             }
@@ -227,7 +227,7 @@ public struct Tokenizer {
             return results.filter { result in
                     rangesToIgnore.filter { $0 ~= result.range.location }.isEmpty
                 }.map {
-                    let libraryRange = $0.rangeAt(1)
+                    let libraryRange = $0.range(at: 1)
                     let fromIndex = source.index(source.startIndex, offsetBy: libraryRange.location)
                     let toIndex = source.index(fromIndex, offsetBy: libraryRange.length)
                     let library = source.substring(with: fromIndex..<toIndex)

--- a/Generator/Source/CuckooGeneratorFramework/Utils.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Utils.swift
@@ -20,15 +20,15 @@ extension String {
 
     subscript(range: Range<Int>) -> String {
         let stringRange = characters.index(startIndex, offsetBy: range.lowerBound)..<characters.index(startIndex, offsetBy: range.upperBound)
-        return self[stringRange]
+        return String(self[stringRange])
     }
 }
 
 extension String.UTF8View {
     subscript(range: Range<Int>) -> String {
         let stringRange = index(startIndex, offsetBy: range.lowerBound)..<index(startIndex, offsetBy: range.upperBound)
-        let selected: String.UTF8View = self[stringRange]
-        return String(selected) ?? ""
+        let subsequence: String.UTF8View.SubSequence = self[stringRange]
+        return String(subsequence) ?? ""
     }
 }
 

--- a/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
+++ b/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
@@ -57,7 +57,7 @@ public struct GenerateMocksCommand: CommandProtocol {
         }
         
         let couldNotOpenFile = inputFiles.contains { $0 == nil }
-        return stderrUsed || couldNotOpenFile ? .failure(.stderrUsed) : .success()
+        return stderrUsed || couldNotOpenFile ? .failure(.stderrUsed) : .success(())
     }
 
     private func mergeInheritance(_ filesRepresentation: [FileRepresentation]) -> [FileRepresentation] {

--- a/Generator/Source/cuckoo_generator/VersionCommand.swift
+++ b/Generator/Source/cuckoo_generator/VersionCommand.swift
@@ -21,7 +21,7 @@ public struct VersionCommand: CommandProtocol {
 
     public func run(_ options: Options) -> Result<Void, CuckooGeneratorError> {
         print(VersionCommand.appVersion)
-        return .success()
+        return .success(())
     }
 
     public struct Options: OptionsProtocol {


### PR DESCRIPTION
- Created new swift 4 Package, and updated to latest API.
- Updated package dependencies.  Note: FileKit points to /develop branch, this should be updated once a Swift 4 version is released.
- Required code changes to build in Swift-4.0