### PR TITLE
Make handling of input files deterministic

### DIFF
--- a/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
+++ b/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
@@ -24,8 +24,8 @@ public struct GenerateMocksCommand: CommandProtocol {
     
     public func run(_ options: Options) -> Result<Void, CuckooGeneratorError> {
         let inputPathValues = Array(Set(options.files.map { Path($0).standardRawValue }))
-        let inputFiles = inputPathValues.map { File(path: $0) }
-        let tokens = inputFiles.flatMap { $0 }.map { Tokenizer(sourceFile: $0).tokenize() }
+        let inputFiles = inputPathValues.map { File(path: $0) }.flatMap { $0 }.sorted(by: { $0.path ?? "" > $1.path ?? "" })
+        let tokens = inputFiles.map { Tokenizer(sourceFile: $0).tokenize() }
         let tokensWithInheritance = options.noInheritance ? tokens : mergeInheritance(tokens)
         let tokensWithoutClasses = options.noClassMocking ? removeClasses(tokensWithInheritance) : tokensWithInheritance
         // filter excluded classes/protocols


### PR DESCRIPTION
Fix for https://github.com/Brightify/Cuckoo/issues/157

Given the same input the generated output should be the same.

I would have loved to have added tests for this.. but I was unable to get the whole workspace (Cuckoo + Generator) to build properly... a guide for contributors to get setup locally would be appreciated 👍 