### PR TITLE
Fix sameInstance(as:) ambiguous reference compile-time error.

### DIFF
--- a/Source/Matching/ParameterMatcherFunctions.swift
+++ b/Source/Matching/ParameterMatcherFunctions.swift
@@ -75,7 +75,7 @@ public func sameInstance<T: AnyObject>(as object: T?) -> ParameterMatcher<T?> {
 }
 
 /// Returns an identity matcher.
-public func sameInstance<T: AnyObject>(as object: T) -> ParameterMatcher<T?> {
+public func sameInstance<T: AnyObject>(as object: T) -> ParameterMatcher<T> {
     return equal(to: object, equalWhen: ===)
 }
 


### PR DESCRIPTION
This patch resolves a compile-time error can can occur when attempting to use the parameter matcher function `sameInstance(as:)`. The error message generated by the compiler is the following:
> Ambiguous reference to member 'sameInstance(as:)'

Prior to this patch, the error is reproduced by the following code snipet:
```swift
class Foo()  { }
func takesMatchableFoo<M1: Matchable>(_ matchable: M1) where M1.MatchedType == Foo { }

takesMatchableFoo(sameInstance(as: Foo())) // Ambiguous reference to member 'sameInstance(as:)'
```