### PR TITLE
Fixes a regression introduced in 96ebbbf

### DIFF
--- a/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
+++ b/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
@@ -23,8 +23,8 @@ public struct GenerateMocksCommand: CommandProtocol {
     public let function = "Generates mock files"
     
     public func run(_ options: Options) -> Result<Void, CuckooGeneratorError> {
-        let inputPathValues = Array(Set(options.files.map { Path($0).standardRawValue }))
-        let inputFiles = inputPathValues.map { File(path: $0) }.flatMap { $0 }.sorted(by: { $0.path ?? "" > $1.path ?? "" })
+        let inputPathValues = Array(Set(options.files.map { Path($0).standardRawValue }.sorted()))
+        let inputFiles = inputPathValues.map { File(path: $0) }.flatMap { $0 }
         let tokens = inputFiles.map { Tokenizer(sourceFile: $0).tokenize() }
         let tokensWithInheritance = options.noInheritance ? tokens : mergeInheritance(tokens)
         let tokensWithoutClasses = options.noClassMocking ? removeClasses(tokensWithInheritance) : tokensWithInheritance


### PR DESCRIPTION
There was an attempt to make the file order deterministic in 96ebbbf, but the sorting that was added only worked if all mocks were generated in a single file. If generated to a path, which creates a file per mock, the filenames and the file contents did not match. Solution was to sort the set of paths passed in as options instead, moving the sorting a little earlier than before.