### PR TITLE
The sort of input files occurred to soon

### DIFF
--- a/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
+++ b/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
@@ -23,7 +23,7 @@ public struct GenerateMocksCommand: CommandProtocol {
     public let function = "Generates mock files"
     
     public func run(_ options: Options) -> Result<Void, CuckooGeneratorError> {
-        let inputPathValues = Array(Set(options.files.map { Path($0).standardRawValue }.sorted()))
+        let inputPathValues = Array(Set(options.files.map { Path($0).standardRawValue })).sorted()
         let inputFiles = inputPathValues.map { File(path: $0) }.flatMap { $0 }
         let tokens = inputFiles.map { Tokenizer(sourceFile: $0).tokenize() }
         let tokensWithInheritance = options.noInheritance ? tokens : mergeInheritance(tokens)


### PR DESCRIPTION
The files input via options are mapped to Path objects then sorted. This actually happened too soon, since the array is then converted to a Set, then converted back to an Array. The Set conversion changes the order (since it is unordered) and those we lost the effect of the sort. I move the sort to the correct place, which is on the outermost Array so that the inputPathValues array is now correctly sorted.