### PR TITLE
clear GREP_OPTIONS environment variable to avoid error.

### DIFF
--- a/Cuckoo.podspec
+++ b/Cuckoo.podspec
@@ -23,6 +23,7 @@ Pod::Spec.new do |s|
   s.preserve_paths              = ['Generator/**/*', 'run', 'build_generator']
   generator_name                = 'cuckoo_generator'
   s.prepare_command             = <<-CMD
+                                    GREP_OPTIONS=
                                     curl -Lo #{generator_name} `curl "https://api.github.com/repos/Brightify/Cuckoo/releases/tags/#{s.version}" | grep -oe '"browser_download_url":\s*"[^" ]*"' | grep -oe 'http[^" ]*' | grep #{generator_name} | head -1`
                                 CMD
   s.frameworks                  = 'XCTest', 'Foundation'

--- a/run
+++ b/run
@@ -3,6 +3,7 @@
 SCRIPT_PATH="$(dirname "$0")"
 FILE_NAME="cuckoo_generator"
 FILE_PATH="$SCRIPT_PATH/$FILE_NAME"
+GREP_OPTIONS=
 if [[ ! -e "$FILE_PATH" ]]; then
   echo "No Cuckoo Generator found, downloading latest version..."
   pushd "$SCRIPT_PATH"


### PR DESCRIPTION
This pull request solves the issue:
https://github.com/Brightify/Cuckoo/issues/183
