### PR TITLE
[WIP] Reintroduce support for pre-0.11.0 Cuckoo spies.

### DIFF
--- a/Cuckoo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Cuckoo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Generator/Package.resolved
+++ b/Generator/Package.resolved
@@ -47,15 +47,6 @@
         }
       },
       {
-        "package": "SWXMLHash",
-        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
-        "state": {
-          "branch": null,
-          "revision": "88095d2bb1d2deb9ea9d9963737871049b21e1b4",
-          "version": "4.2.1"
-        }
-      },
-      {
         "package": "SourceKit",
         "repositoryURL": "https://github.com/norio-nomura/SourceKit.git",
         "state": {
@@ -89,6 +80,15 @@
           "branch": null,
           "revision": "65a461d0a103896c8ff7e3f17f7be1a5badadeb0",
           "version": "0.9.0"
+        }
+      },
+      {
+        "package": "SWXMLHash",
+        "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
+        "state": {
+          "branch": null,
+          "revision": "88095d2bb1d2deb9ea9d9963737871049b21e1b4",
+          "version": "4.2.1"
         }
       },
       {

--- a/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
@@ -14,7 +14,15 @@ class {{ container.mockName }}: {{ container.name }}, {% if container.isImplemen
     typealias MocksType = {{ container.name }}
     typealias Stubbing = __StubbingProxy_{{ container.name }}
     typealias Verification = __VerificationProxy_{{ container.name }}
+
+    private var __defaultImplStub: {{ container.name }}?
+
     let cuckoo_manager = Cuckoo.MockManager(hasParent: {{ container.isImplementation }})
+
+    func enableDefaultImplementation(_ stub: {{ container.name }}) {
+        __defaultImplStub = stub
+        cuckoo_manager.enableDefaultStubImplementation()
+    }
 
     {% for property in container.properties %}
     {% if debug %}
@@ -22,19 +30,26 @@ class {{ container.mockName }}: {{ container.name }}, {% if container.isImplemen
     {% endif %}
     {{ property.accessibility }}{% if container.isImplementation %} override{% endif %} var {{ property.name }}: {{ property.type }} {
         get {
-            {% if container.isImplementation %}
-            return cuckoo_manager.getter("{{ property.name }}", superclassCall: super.{{ property.name }})
-            {% else %}
-            return cuckoo_manager.getter("{{ property.name }}", superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall())
-            {% endif %}
+            return cuckoo_manager.getter("{{ property.name }}",
+                superclassCall:
+                    {% if container.isImplementation %}
+                    super.{{ property.name }}
+                    {% else %}
+                    Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                    {% endif %},
+                defaultCall: __defaultImplStub!.{{property.name}})
         }
         {% ifnot property.isReadOnly %}
         set {
-            {% if container.isImplementation %}
-            cuckoo_manager.setter("{{ property.name }}", value: newValue, superclassCall: super.{{ property.name }} = newValue)
-            {% else %}
-            cuckoo_manager.setter("{{ property.name }}", value: newValue, superclassCall: Cuckoo.MockManager.crashOnProtocolSuperclassCall())
-            {% endif %}
+            cuckoo_manager.setter("{{ property.name }}",
+                value: newValue,
+                superclassCall:
+                    {% if container.isImplementation %}
+                    super.{{ property.name }} = newValue
+                    {% else %}
+                    Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                    {% endif %},
+                defaultCall: __defaultImplStub!.{{property.name}} = newValue)
         }
         {% endif %}
     }
@@ -60,7 +75,8 @@ class {{ container.mockName }}: {{ container.name }}, {% if container.isImplemen
                     super.{{method.name}}({{method.call}})
                     {% else %}
                     Cuckoo.MockManager.crashOnProtocolSuperclassCall()
-                    {% endif %})
+                    {% endif %},
+                defaultCall: __defaultImplStub!.{{method.name}}{%if method.isOptional %}!{%endif%}({{method.call}}))
         {{ method.parameters|closeNestedClosure }}
     }
     {% endfor %}

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -58,7 +58,9 @@ public struct Tokenizer {
 
         let attributes = dictionary[Key.Attributes.rawValue] as? [Any]
 
-        let attributeOptional = attributes?.first(where: {($0 as? [String : String])?[Key.Attribute.rawValue] == Kinds.Optional.rawValue}) != nil
+        let attributeOptional = attributes?.first(where: {
+            ($0 as? [String : SourceKitRepresentable])?[Key.Attribute.rawValue]?.isEqualTo(Kinds.Optional.rawValue) == true
+        }) != nil
 
         let accessibility = (dictionary[Key.Accessibility.rawValue] as? String).flatMap { Accessibility(rawValue: $0) }
         let type = dictionary[Key.TypeName.rawValue] as? String

--- a/Source/Mock/Mock.swift
+++ b/Source/Mock/Mock.swift
@@ -18,6 +18,8 @@ public protocol Mock: HasMockManager {
     func getStubbingProxy() -> Stubbing
     
     func getVerificationProxy(_ callMatcher: CallMatcher, sourceLocation: SourceLocation) -> Verification
+
+    func enableDefaultImplementation(_ stub: MocksType)
 }
 
 public extension Mock {
@@ -27,6 +29,11 @@ public extension Mock {
     
     func getVerificationProxy(_ callMatcher: CallMatcher, sourceLocation: SourceLocation) -> Verification {
         return Verification(manager: cuckoo_manager, callMatcher: callMatcher, sourceLocation: sourceLocation)
+    }
+
+    func withEnabledDefaultImplementation(_ stub: MocksType) -> Self {
+        enableDefaultImplementation(stub)
+        return self
     }
 }
 

--- a/Tests/ClassTest.swift
+++ b/Tests/ClassTest.swift
@@ -165,6 +165,13 @@ class ClassTest: XCTestCase {
         verify(mock).callingCountCharactersMethodWithHello()
         verify(mock).count(characters: "Hello")
     }
+
+    func testDefaultImplCall() {
+        mock.enableDefaultImplementation(TestedClassStub())
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+    }
     
     private enum TestError: Error {
         case unknown


### PR DESCRIPTION
This PR reintroduces support for pre-0.11.0 spies, but we're calling them "default implementation" instead of "spy".

## WIP

- [ ] Tests
- [ ] Documentation