### PR TITLE
Add support for importing subtypes directly.

### DIFF
--- a/Generator/Source/CuckooGeneratorFramework/FileHeaderHandler.swift
+++ b/Generator/Source/CuckooGeneratorFramework/FileHeaderHandler.swift
@@ -24,7 +24,7 @@ public struct FileHeaderHandler {
     }
 
     public static func getImports(of file: FileRepresentation, testableFrameworks: [String]) -> String {
-        var imports = Array(Set(file.declarations.only(Import.self).map { "import " + $0.library + "\n" })).sorted().joined(separator: "")
+        var imports = Array(Set(file.declarations.only(Import.self).map { "import \($0.importee)" + "\n" })).sorted().joined(separator: "")
         if imports.isEmpty == false {
             imports = "\n" + imports
         }

--- a/Generator/Source/CuckooGeneratorFramework/FileHeaderHandler.swift
+++ b/Generator/Source/CuckooGeneratorFramework/FileHeaderHandler.swift
@@ -24,9 +24,9 @@ public struct FileHeaderHandler {
     }
 
     public static func getImports(of file: FileRepresentation, testableFrameworks: [String]) -> String {
-        var imports = Array(Set(file.declarations.only(Import.self).map { "import \($0.importee)" + "\n" })).sorted().joined(separator: "")
+        var imports = Array(Set(file.declarations.only(Import.self).map { "import \($0.importee)\n" })).sorted().joined(separator: "")
         if imports.isEmpty == false {
-            imports = "\n" + imports
+            imports = "\n\(imports)"
         }
         return "import Cuckoo\n" + getTestableImports(testableFrameworks: testableFrameworks) + imports
     }

--- a/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
@@ -10,7 +10,7 @@ import Foundation
 extension Templates {
     static let mock = """
 {% for container in containers %}
-class {{ container.mockName }}: {{ container.name }}, {% if container.isImplementation %}Cuckoo.ClassMock{% else %}Cuckoo.ProtocolMock{% endif %} {
+{{ container.accessibility }} class {{ container.mockName }}: {{ container.name }}, {% if container.isImplementation %}Cuckoo.ClassMock{% else %}Cuckoo.ProtocolMock{% endif %} {
     typealias MocksType = {{ container.name }}
     typealias Stubbing = __StubbingProxy_{{ container.name }}
     typealias Verification = __VerificationProxy_{{ container.name }}

--- a/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
@@ -31,6 +31,9 @@ extension Templates {
     {% if debug %}
     // {{property}}
     {% endif %}
+    {% for attribute in property.attributes %}
+    {{ attribute.text }}
+    {% endfor %}
     {{ property.accessibility }}{% if container.isImplementation %} override{% endif %} var {{ property.name }}: {{ property.type }} {
         get {
             return cuckoo_manager.getter("{{ property.name }}",
@@ -73,6 +76,9 @@ extension Templates {
     {% if debug %}
     // {{method}}
     {% endif %}
+    {% for attribute in method.attributes %}
+    {{ attribute.text }}
+    {% endfor %}
     {{ method.accessibility }}{% if container.isImplementation and method.isOverriding %} override{% endif %} func {{ method.name }}({{ method.parameterSignature }}) {{ method.returnSignature }} {
         {{ method.parameters|openNestedClosure:method.isThrowing }}
             return{% if method.isThrowing %} try{% endif %} cuckoo_manager.call{% if method.isThrowing %}Throws{% endif %}("{{method.fullyQualifiedName}}",

--- a/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
@@ -11,15 +11,15 @@ extension Templates {
     static let mock = """
 {% for container in containers %}
 {{ container.accessibility }} class {{ container.mockName }}: {{ container.name }}, {% if container.isImplementation %}Cuckoo.ClassMock{% else %}Cuckoo.ProtocolMock{% endif %} {
-    typealias MocksType = {{ container.name }}
-    typealias Stubbing = __StubbingProxy_{{ container.name }}
-    typealias Verification = __VerificationProxy_{{ container.name }}
+    {{ container.accessibility }} typealias MocksType = {{ container.name }}
+    {{ container.accessibility }} typealias Stubbing = __StubbingProxy_{{ container.name }}
+    {{ container.accessibility }} typealias Verification = __VerificationProxy_{{ container.name }}
 
     private var __defaultImplStub: {{ container.name }}?
 
-    let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: {{ container.isImplementation }})
+    {{ container.accessibility }} let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: {{ container.isImplementation }})
 
-    func enableDefaultImplementation(_ stub: {{ container.name }}) {
+    {{ container.accessibility }} func enableDefaultImplementation(_ stub: {{ container.name }}) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }

--- a/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
@@ -10,6 +10,9 @@ import Foundation
 extension Templates {
     static let mock = """
 {% for container in containers %}
+{% for attribute in container.attributes %}
+{{ attribute }}
+{% endfor %}
 {{ container.accessibility }} class {{ container.mockName }}: {{ container.name }}, {% if container.isImplementation %}Cuckoo.ClassMock{% else %}Cuckoo.ProtocolMock{% endif %} {
     {{ container.accessibility }} typealias MocksType = {{ container.name }}
     {{ container.accessibility }} typealias Stubbing = __StubbingProxy_{{ container.name }}

--- a/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
@@ -11,7 +11,7 @@ extension Templates {
     static let mock = """
 {% for container in containers %}
 {% for attribute in container.attributes %}
-{{ attribute }}
+{{ attribute.text }}
 {% endfor %}
 {{ container.accessibility }} class {{ container.mockName }}: {{ container.name }}, {% if container.isImplementation %}Cuckoo.ClassMock{% else %}Cuckoo.ProtocolMock{% endif %} {
     {{ container.accessibility }} typealias MocksType = {{ container.name }}

--- a/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
@@ -29,7 +29,7 @@ extension Templates {
 
     {% for method in container.methods %}
     {{ method.accessibility }}{% if container.@type == "ClassDeclaration" and method.isOverriding %} override{% endif %} func {{ method.name }}({{ method.parameterSignature }}) {{ method.returnSignature }} {
-        return DefaultValueRegistry.defaultValue(for: {{method.returnType}}.self)
+        return DefaultValueRegistry.defaultValue(for: {{method.returnType|genericSafe}}.self)
     }
     {% endfor %}
 }

--- a/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
@@ -11,7 +11,7 @@ extension Templates {
     {% for property in container.properties %}
     {{ property.accessibility }}{% if container.@type == "ClassDeclaration" %} override{% endif %} var {{ property.name }}: {{ property.type }} {
         get {
-            return DefaultValueRegistry.defaultValue(for: ({{property.type}}).self)
+            return DefaultValueRegistry.defaultValue(for: ({{property.type|genericSafe}}).self)
         }
         {% ifnot property.isReadOnly %}
         set { }

--- a/Generator/Source/CuckooGeneratorFramework/Templates/StubbingProxyTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/StubbingProxyTemplate.swift
@@ -9,10 +9,10 @@ import Foundation
 
 extension Templates {
     static let stubbingProxy = """
-struct __StubbingProxy_{{ container.name }}: Cuckoo.StubbingProxy {
+{{ container.accessibility }} struct __StubbingProxy_{{ container.name }}: Cuckoo.StubbingProxy {
     private let cuckoo_manager: Cuckoo.MockManager
 
-    init(manager: Cuckoo.MockManager) {
+    {{ container.accessibility }} init(manager: Cuckoo.MockManager) {
         self.cuckoo_manager = manager
     }
     {% for property in container.properties %}

--- a/Generator/Source/CuckooGeneratorFramework/Templates/VerificationProxyTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/VerificationProxyTemplate.swift
@@ -9,12 +9,12 @@ import Foundation
 
 extension Templates {
     static let verificationProxy = """
-struct __VerificationProxy_{{ container.name }}: Cuckoo.VerificationProxy {
+{{ container.accessibility }} struct __VerificationProxy_{{ container.name }}: Cuckoo.VerificationProxy {
     private let cuckoo_manager: Cuckoo.MockManager
     private let callMatcher: Cuckoo.CallMatcher
     private let sourceLocation: Cuckoo.SourceLocation
 
-    init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+    {{ container.accessibility }} init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
         self.cuckoo_manager = manager
         self.callMatcher = callMatcher
         self.sourceLocation = sourceLocation

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -12,9 +12,11 @@ import SourceKittenFramework
 public struct Tokenizer {
     private let file: File
     private let source: String
+    private let debugMode: Bool
 
-    public init(sourceFile: File) {
+    public init(sourceFile: File, debugMode: Bool) {
         self.file = sourceFile
+        self.debugMode = debugMode
 
         source = sourceFile.contents
     }
@@ -97,7 +99,9 @@ public struct Tokenizer {
 
         case Kinds.ClassDeclaration.rawValue:
             guard !attributes.map({ $0.kind }).contains(.final) else {
-                fputs("Cuckoo: Ignoring mocking of class \(name) because it's marked `final`.\n", stdout)
+                if debugMode {
+                    fputs("Cuckoo: Ignoring mocking of class \(name) because it's marked `final`.\n", stdout)
+                }
                 return nil
             }
 

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -96,6 +96,11 @@ public struct Tokenizer {
                 attributes: attributes)
 
         case Kinds.ClassDeclaration.rawValue:
+            guard !attributes.map({ $0.kind }).contains(.final) else {
+                fputs("Cuckoo: Ignoring mocking of class \(name) because it's marked `final`.\n", stdout)
+                return nil
+            }
+
             let subtokens = tokenize(dictionary[Key.Substructure.rawValue] as? [SourceKitRepresentable] ?? [])
             let initializers = subtokens.only(Initializer.self)
             let children = subtokens.noneOf(Initializer.self).map { child -> Token in

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -69,7 +69,9 @@ public struct Tokenizer {
                     let stringKind = attribute[Key.Attribute.rawValue] as? String,
                     let kind = Attribute.Kind(rawValue: stringKind),
                     let attributeRange = extractRange(from: attribute, offset: .Offset, length: .Length) else { return nil }
-                let text = String(source.utf8[attributeRange])
+                let startIndex = source.utf8.index(source.utf8.startIndex, offsetBy: attributeRange.lowerBound)
+                let endIndex = source.utf8.index(source.utf8.startIndex, offsetBy: attributeRange.upperBound)
+                guard let text = String(source.utf8[startIndex..<endIndex]) else { return nil }
                 return Attribute(kind: kind, text: text)
             }
 

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -137,7 +137,8 @@ public struct Tokenizer {
                 setterAccessibility: setterAccessibility,
                 range: range!,
                 nameRange: nameRange!,
-                overriding: false)
+                overriding: false,
+                attributes: attributes)
 
         case Kinds.InstanceMethod.rawValue:
             let parameters = tokenize(methodName: name, parameters: dictionary[Key.Substructure.rawValue] as? [SourceKitRepresentable] ?? [])
@@ -169,18 +170,17 @@ public struct Tokenizer {
                     range: range!,
                     nameRange: nameRange!,
                     parameters: parameters,
-                    bodyRange: bodyRange)
+                    bodyRange: bodyRange,
+                    attributes: attributes)
             } else {
-                let attributeOptional = attributes.contains { $0.kind == Attribute.Kind.optional }
-
                 return ProtocolMethod(
                     name: name,
                     accessibility: accessibility!,
                     returnSignature: returnSignature,
-                    isOptional: attributeOptional,
                     range: range!,
                     nameRange: nameRange!,
-                    parameters: parameters)
+                    parameters: parameters,
+                    attributes: attributes)
             }
 
         default:

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -251,9 +251,10 @@ public struct Tokenizer {
         }
 
         do {
-            let baseRegex = "(?:\\b|;)import(?:\\s|(?:\\/\\/.*\n)|(?:\\/\*.*\\*\\/))+"
-            let libraryImportRegex = baseRegex + "([^\\s;\\/]+)\\s+([^\\s;\\/]+)\\.([^\\s;\\/]+)"
-            let componentImportRegex = baseRegex + "([^\\s;\\/]+)"
+            let baseRegex = "(?:\\b|;)import(?:\\s|(?:\\/\\/.*\\n)|(?:\\/\*.*\\*\\/))+"
+            let identifierRegex = "[^\\s;\\/]+"
+            let libraryImportRegex = baseRegex + "(\(identifierRegex))\\s+(\(identifierRegex))\\.(\(identifierRegex))"
+            let componentImportRegex = baseRegex + "(\(identifierRegex))"
             let libraryRegex = try NSRegularExpression(libraryImportRegex)
             let componentRegex = try NSRegularExpression(libraryImportRegex)
             let libraries = libraryRegex.matches(in: source, range: NSMakeRange(0, source.count))

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Attribute.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Attribute.swift
@@ -16,4 +16,5 @@ public enum Attribute: String {
     case weak = "source.decl.attribute.weak"
     case ibAction = "source.decl.attribute.ibaction"
     case ibOutlet = "source.decl.attribute.iboutlet"
+    case available = "source.decl.attribute.available"
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Attribute.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Attribute.swift
@@ -18,6 +18,7 @@ public struct Attribute {
         case ibAction = "source.decl.attribute.ibaction"
         case ibOutlet = "source.decl.attribute.iboutlet"
         case available = "source.decl.attribute.available"
+        case final = "source.decl.attribute.final"
     }
 
     public var kind: Kind
@@ -25,7 +26,7 @@ public struct Attribute {
 
     public var isSupported: Bool {
         switch (kind) {
-        case .objc, .optional, .lazy, .required, .override, .convenience, .weak, .ibAction, .ibOutlet:
+        case .objc, .optional, .lazy, .required, .override, .convenience, .weak, .ibAction, .ibOutlet, .final:
             return false
         case .available:
             return true

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Attribute.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Attribute.swift
@@ -6,15 +6,31 @@
 //
 //
 
-public enum Attribute: String {
-    case objc = "source.decl.attribute.objc"
-    case optional = "source.decl.attribute.optional"
-    case lazy = "source.decl.attribute.lazy"
-    case required = "source.decl.attribute.required"
-    case override = "source.decl.attribute.override"
-    case convenience = "source.decl.attribute.convenience"
-    case weak = "source.decl.attribute.weak"
-    case ibAction = "source.decl.attribute.ibaction"
-    case ibOutlet = "source.decl.attribute.iboutlet"
-    case available = "source.decl.attribute.available"
+public struct Attribute {
+    public enum Kind: String {
+        case objc = "source.decl.attribute.objc"
+        case optional = "source.decl.attribute.optional"
+        case lazy = "source.decl.attribute.lazy"
+        case required = "source.decl.attribute.required"
+        case override = "source.decl.attribute.override"
+        case convenience = "source.decl.attribute.convenience"
+        case weak = "source.decl.attribute.weak"
+        case ibAction = "source.decl.attribute.ibaction"
+        case ibOutlet = "source.decl.attribute.iboutlet"
+        case available = "source.decl.attribute.available"
+    }
+
+    public var kind: Kind
+    public var text: String
+}
+
+extension Attribute: Token {
+    public func isEqual(to other: Token) -> Bool {
+        guard let otherAttribute = other as? Attribute else { return false }
+        return self.kind == otherAttribute.kind && self.text == otherAttribute.text
+    }
+
+    public func serialize() -> [String : Any] {
+        return ["text": text]
+    }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Attribute.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Attribute.swift
@@ -22,6 +22,15 @@ public struct Attribute {
 
     public var kind: Kind
     public var text: String
+
+    public var isSupported: Bool {
+        switch (kind) {
+        case .objc, .optional, .lazy, .required, .override, .convenience, .weak, .ibAction, .ibOutlet:
+            return false
+        case .available:
+            return true
+        }
+    }
 }
 
 extension Attribute: Token {

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
@@ -23,14 +23,17 @@ public struct ClassDeclaration: ContainerToken {
     }
 
     public func replace(children tokens: [Token]) -> ClassDeclaration {
-        return ClassDeclaration(name: self.name,
-                accessibility: self.accessibility,
-                range: self.range,
-                nameRange: self.nameRange,
-                bodyRange: self.bodyRange,
-                initializers: self.initializers,
-                children: tokens,
-                inheritedTypes: self.inheritedTypes)
+        return ClassDeclaration(
+            name: self.name,
+            accessibility: self.accessibility,
+            range: self.range,
+            nameRange: self.nameRange,
+            bodyRange: self.bodyRange,
+            initializers: self.initializers,
+            children: tokens,
+            implementation: self.implementation,
+            inheritedTypes: self.inheritedTypes,
+            attributes: self.attributes)
     }
 
     public func isEqual(to other: Token) -> Bool {

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
@@ -16,7 +16,7 @@ public struct ClassDeclaration: ContainerToken {
     public let children: [Token]
     public let implementation: Bool = true
     public let inheritedTypes: [InheritanceDeclaration]
-    public let attributes: [Attribute] = []
+    public let attributes: [Attribute]
     
     public var hasNoArgInit: Bool {
         return initializers.filter { $0.parameters.isEmpty }.isEmpty
@@ -31,7 +31,6 @@ public struct ClassDeclaration: ContainerToken {
             bodyRange: self.bodyRange,
             initializers: self.initializers,
             children: tokens,
-            implementation: self.implementation,
             inheritedTypes: self.inheritedTypes,
             attributes: self.attributes)
     }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ClassMethod.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ClassMethod.swift
@@ -13,9 +13,8 @@ public struct ClassMethod: Method {
     public let range: CountableRange<Int>
     public let nameRange: CountableRange<Int>
     public let parameters: [MethodParameter]
-
     public let bodyRange: CountableRange<Int>
-
+    public let attributes: [Attribute]
     public var isOptional: Bool {
         return false
     }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
@@ -35,7 +35,7 @@ extension ContainerToken {
 
         return [
             "name": name,
-            "accessibility": accessibility,
+            "accessibility": accessibility.sourceName,
             "isAccessible": accessibility.isAccessible,
             "children": children.map { $0.serializeWithType() },
             "properties": properties,

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
@@ -44,7 +44,7 @@ extension ContainerToken {
             "isImplementation": implementation,
             "mockName": "Mock\(name)",
             "inheritedTypes": inheritedTypes,
-            "attributes": attributes
+            "attributes": attributes.filter { $0.isSupported },
         ]
     }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
@@ -42,7 +42,9 @@ extension ContainerToken {
             "methods": methods,
             "initializers": implementation ? [] : initializers,
             "isImplementation": implementation,
-            "mockName": "Mock\(name)"
+            "mockName": "Mock\(name)",
+            "inheritedTypes": inheritedTypes,
+            "attributes": attributes
         ]
     }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Import.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Import.swift
@@ -7,11 +7,32 @@
 //
 
 public struct Import: Token {
+    public enum Importee: CustomStringConvertible {
+        case library(name: String)
+        case component(componentType: String, library: String, name: String)
+
+        var description: {
+            switch self {
+            case .library(let name):
+                return name
+            case .component(let componentType, let library, let name):
+                return "\(componentType) \(library).\(name)"
+            }
+        }
+    }
+
     public let range: CountableRange<Int>
-    public let library: String
+    public let importee: Importee
 
     public func isEqual(to other: Token) -> Bool {
-        guard let other = other as? Import else { return false }
-        return self.range == other.range && self.library == other.library
+        guard let other = other as? Import, self.range == other.range else { return false }
+        switch (self, other) {
+        case (.library(let lhsName), .library(let rhsName)):
+            return lhsName == rhsName
+        case (.component(let lhsImportType, let lhsLibrary, let lhsName), .component(let rhsImportType, let rhsLibrary, let rhsName)):
+            return lhsImportType == rhsImportType && lhsLibrary == rhsLibrary && lhsName == rhsName
+        default:
+            return false
+        }
     }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Import.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Import.swift
@@ -9,14 +9,14 @@
 public struct Import: Token {
     public enum Importee: CustomStringConvertible {
         case library(name: String)
-        case component(componentType: String, library: String, name: String)
+        case component(componentType: String?, library: String, name: String)
 
-        var description: {
+        public var description: String {
             switch self {
             case .library(let name):
                 return name
             case .component(let componentType, let library, let name):
-                return "\(componentType) \(library).\(name)"
+                return [componentType, "\(library).\(name)"].compactMap { $0 }.joined(separator: " ")
             }
         }
     }
@@ -26,7 +26,7 @@ public struct Import: Token {
 
     public func isEqual(to other: Token) -> Bool {
         guard let other = other as? Import, self.range == other.range else { return false }
-        switch (self, other) {
+        switch (self.importee, other.importee) {
         case (.library(let lhsName), .library(let rhsName)):
             return lhsName == rhsName
         case (.component(let lhsImportType, let lhsLibrary, let lhsName), .component(let rhsImportType, let rhsLibrary, let rhsName)):

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Initializer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Initializer.swift
@@ -15,10 +15,9 @@ public struct Initializer: Method {
     public let parameters: [MethodParameter]
     public let isOverriding: Bool
     public let required: Bool
+    public let attributes: [Attribute]
 
     public var isOptional: Bool {
         return false
     }
-
-
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/InstanceVariable.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/InstanceVariable.swift
@@ -29,14 +29,13 @@ public struct InstanceVariable: Token {
     }
 
     public func serialize() -> [String : Any] {
+        let readOnlyString = readOnly ? "ReadOnly" : ""
         return [
             "name": name,
             "type": type,
             "accessibility": accessibility.sourceName,
             "isReadOnly": readOnly,
-            "stubType": readOnly ?
-                (overriding ? "ClassToBeStubbedReadOnlyProperty" : "ProtocolToBeStubbedReadOnlyProperty") :
-                (overriding ? "ClassToBeStubbedProperty" : "ProtocolToBeStubbedProperty")
+            "stubType": overriding ? "ClassToBeStubbed\(readOnlyString)Property" : "ProtocolToBeStubbed\(readOnlyString)Property"
         ]
     }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/InstanceVariable.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/InstanceVariable.swift
@@ -7,14 +7,15 @@
 //
 
 public struct InstanceVariable: Token {
-    public var name: String
-    public var type: String
-    public var accessibility: Accessibility
-    public var setterAccessibility: Accessibility?
-    public var range: CountableRange<Int>
-    public var nameRange: CountableRange<Int>
+    public let name: String
+    public let type: String
+    public let accessibility: Accessibility
+    public let setterAccessibility: Accessibility?
+    public let range: CountableRange<Int>
+    public let nameRange: CountableRange<Int>
     public var overriding: Bool
-    
+    public let attributes: [Attribute]
+
     public var readOnly: Bool {
         if let setterAccessibility = setterAccessibility {
             return !setterAccessibility.isAccessible
@@ -35,7 +36,8 @@ public struct InstanceVariable: Token {
             "type": type,
             "accessibility": accessibility.sourceName,
             "isReadOnly": readOnly,
-            "stubType": overriding ? "ClassToBeStubbed\(readOnlyString)Property" : "ProtocolToBeStubbed\(readOnlyString)Property"
+            "stubType": overriding ? "ClassToBeStubbed\(readOnlyString)Property" : "ProtocolToBeStubbed\(readOnlyString)Property",
+            "attributes": attributes.filter { $0.isSupported },
         ]
     }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Kinds.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Kinds.swift
@@ -13,5 +13,4 @@ public enum Kinds: String {
     case ClassDeclaration = "source.lang.swift.decl.class"
     case ExtensionDeclaration = "source.lang.swift.decl.extension"
     case InstanceVariable = "source.lang.swift.decl.var.instance"
-    case Optional = "source.decl.attribute.optional"
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Method.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Method.swift
@@ -1,5 +1,5 @@
 //
-//  .swift
+//  Method.swift
 //  CuckooGenerator
 //
 //  Created by Filip Dolnik on 30.05.16.
@@ -16,6 +16,7 @@ public protocol Method: Token {
     var isOptional: Bool { get }
     var isOverriding: Bool { get }
     var hasClosureParams: Bool { get }
+    var attributes: [Attribute] { get }
 }
 
 public extension Method {
@@ -117,7 +118,8 @@ public extension Method {
             "stubFunction": stubFunction,
             "inputTypes": parameters.map { $0.typeWithoutAttributes }.joined(separator: ", "),
             "isOptional": isOptional,
-            "hasClosureParams": hasClosureParams
+            "hasClosureParams": hasClosureParams,
+            "attributes": attributes.filter { $0.isSupported },
         ]
     }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
@@ -19,14 +19,17 @@ public struct ProtocolDeclaration: ContainerToken {
     public let attributes: [Attribute] = []
 
     public func replace(children tokens: [Token]) -> ProtocolDeclaration {
-        return ProtocolDeclaration(name: self.name,
-                accessibility: self.accessibility,
-                range: self.range,
-                nameRange: self.nameRange,
-                bodyRange: self.bodyRange,
-                initializers: self.initializers,
-                children: tokens,
-                inheritedTypes: self.inheritedTypes)
+        return ProtocolDeclaration(
+            name: self.name,
+            accessibility: self.accessibility,
+            range: self.range,
+            nameRange: self.nameRange,
+            bodyRange: self.bodyRange,
+            initializers: self.initializers,
+            children: tokens,
+            implementation: self.implementation
+            inheritedTypes: self.inheritedTypes,
+            attributes: self.attributes)
     }
 
     public func isEqual(to other: Token) -> Bool {

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
@@ -16,7 +16,7 @@ public struct ProtocolDeclaration: ContainerToken {
     public let children: [Token]
     public let implementation: Bool = false
     public let inheritedTypes: [InheritanceDeclaration]
-    public let attributes: [Attribute] = []
+    public let attributes: [Attribute]
 
     public func replace(children tokens: [Token]) -> ProtocolDeclaration {
         return ProtocolDeclaration(
@@ -27,9 +27,8 @@ public struct ProtocolDeclaration: ContainerToken {
             bodyRange: self.bodyRange,
             initializers: self.initializers,
             children: tokens,
-            implementation: self.implementation
             inheritedTypes: self.inheritedTypes,
-            attributes: self.attributes)
+            attributes: self.attributes.filter { $0.kind != Attribute.Kind.objc })
     }
 
     public func isEqual(to other: Token) -> Bool {

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
@@ -28,7 +28,7 @@ public struct ProtocolDeclaration: ContainerToken {
             initializers: self.initializers,
             children: tokens,
             inheritedTypes: self.inheritedTypes,
-            attributes: self.attributes.filter { $0.kind != Attribute.Kind.objc })
+            attributes: self.attributes)
     }
 
     public func isEqual(to other: Token) -> Bool {

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolMethod.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolMethod.swift
@@ -10,10 +10,14 @@ public struct ProtocolMethod: Method {
     public let name: String
     public let accessibility: Accessibility
     public let returnSignature: String
-    public let isOptional: Bool
     public let range: CountableRange<Int>
     public let nameRange: CountableRange<Int>
     public let parameters: [MethodParameter]
+    public let attributes: [Attribute]
+    
+    public var isOptional: Bool {
+        return attributes.map { $0.kind }.contains(.optional)
+    }
     public var isOverriding: Bool {
         return false
     }

--- a/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
+++ b/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
@@ -37,7 +37,7 @@ public struct GenerateMocksCommand: CommandProtocol {
             inputPathValues = getFullPathSortedArray(options.files)
         }
         let inputFiles = inputPathValues.map { File(path: $0) }.compactMap { $0 }
-        let tokens = inputFiles.map { Tokenizer(sourceFile: $0).tokenize() }
+        let tokens = inputFiles.map { Tokenizer(sourceFile: $0, debugMode: options.debugMode).tokenize() }
         let tokensWithInheritance = options.noInheritance ? tokens : mergeInheritance(tokens)
 
         // filter classes/protocols based on the settings passed to the generator

--- a/Tests/Source/TestedClass.swift
+++ b/Tests/Source/TestedClass.swift
@@ -201,3 +201,4 @@ final class FinalClass {
 
 // should generate a compiler error if `FinalClass` isn't ignored and `MockFinalClass` is generated
 class MockFinalClass {}
+class FinalClassStub {}

--- a/Tests/Source/TestedClass.swift
+++ b/Tests/Source/TestedClass.swift
@@ -194,3 +194,7 @@ class ClassUsingInnerEnum {
         return .foo
     }
 }
+
+final class FinalClass {
+    var shouldBeIgnoredByCuckoo = true
+}

--- a/Tests/Source/TestedClass.swift
+++ b/Tests/Source/TestedClass.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(swift 4.0)
 class TestedClass {
     
     let constant: Float = 0.0

--- a/Tests/Source/TestedClass.swift
+++ b/Tests/Source/TestedClass.swift
@@ -198,3 +198,6 @@ class ClassUsingInnerEnum {
 final class FinalClass {
     var shouldBeIgnoredByCuckoo = true
 }
+
+// should generate a compiler error if `FinalClass` isn't ignored and `MockFinalClass` is generated
+class MockFinalClass {}

--- a/Tests/Source/TestedClass.swift
+++ b/Tests/Source/TestedClass.swift
@@ -6,7 +6,9 @@
 //  Copyright © 2016 Brightify. All rights reserved.
 //
 
-import Foundation
+import UIKit.DocumentManager  ; import Foundation
+import class UIKit.UIFont
+import UIKit
 
 @available(swift 4.0)
 class TestedClass {


### PR DESCRIPTION
For example `import struct Libraria.Alexandria`.
As it's not allowed in Swift for now, there are no whitespaces allowed before or after the dot. It is allowed between the component type and library name.

Fixes #204.