### PR TITLE
Show class accessibility.

### DIFF
--- a/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
@@ -10,7 +10,7 @@ import Foundation
 extension Templates {
     static let mock = """
 {% for container in containers %}
-class {{ container.mockName }}: {{ container.name }}, {% if container.isImplementation %}Cuckoo.ClassMock{% else %}Cuckoo.ProtocolMock{% endif %} {
+{{ container.accessibility }} class {{ container.mockName }}: {{ container.name }}, {% if container.isImplementation %}Cuckoo.ClassMock{% else %}Cuckoo.ProtocolMock{% endif %} {
     typealias MocksType = {{ container.name }}
     typealias Stubbing = __StubbingProxy_{{ container.name }}
     typealias Verification = __VerificationProxy_{{ container.name }}

--- a/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
@@ -11,15 +11,15 @@ extension Templates {
     static let mock = """
 {% for container in containers %}
 {{ container.accessibility }} class {{ container.mockName }}: {{ container.name }}, {% if container.isImplementation %}Cuckoo.ClassMock{% else %}Cuckoo.ProtocolMock{% endif %} {
-    typealias MocksType = {{ container.name }}
-    typealias Stubbing = __StubbingProxy_{{ container.name }}
-    typealias Verification = __VerificationProxy_{{ container.name }}
+    {{ container.accessibility }} typealias MocksType = {{ container.name }}
+    {{ container.accessibility }} typealias Stubbing = __StubbingProxy_{{ container.name }}
+    {{ container.accessibility }} typealias Verification = __VerificationProxy_{{ container.name }}
 
     private var __defaultImplStub: {{ container.name }}?
 
-    let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: {{ container.isImplementation }})
+    {{ container.accessibility }} let cuckoo_manager = Cuckoo.MockManager.preconfiguredManager ?? Cuckoo.MockManager(hasParent: {{ container.isImplementation }})
 
-    func enableDefaultImplementation(_ stub: {{ container.name }}) {
+    {{ container.accessibility }} func enableDefaultImplementation(_ stub: {{ container.name }}) {
         __defaultImplStub = stub
         cuckoo_manager.enableDefaultStubImplementation()
     }

--- a/Generator/Source/CuckooGeneratorFramework/Templates/StubbingProxyTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/StubbingProxyTemplate.swift
@@ -9,10 +9,10 @@ import Foundation
 
 extension Templates {
     static let stubbingProxy = """
-struct __StubbingProxy_{{ container.name }}: Cuckoo.StubbingProxy {
+{{ container.accessibility }} struct __StubbingProxy_{{ container.name }}: Cuckoo.StubbingProxy {
     private let cuckoo_manager: Cuckoo.MockManager
 
-    init(manager: Cuckoo.MockManager) {
+    {{ container.accessibility }} init(manager: Cuckoo.MockManager) {
         self.cuckoo_manager = manager
     }
     {% for property in container.properties %}

--- a/Generator/Source/CuckooGeneratorFramework/Templates/VerificationProxyTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/VerificationProxyTemplate.swift
@@ -9,12 +9,12 @@ import Foundation
 
 extension Templates {
     static let verificationProxy = """
-struct __VerificationProxy_{{ container.name }}: Cuckoo.VerificationProxy {
+{{ container.accessibility }} struct __VerificationProxy_{{ container.name }}: Cuckoo.VerificationProxy {
     private let cuckoo_manager: Cuckoo.MockManager
     private let callMatcher: Cuckoo.CallMatcher
     private let sourceLocation: Cuckoo.SourceLocation
 
-    init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
+    {{ container.accessibility }} init(manager: Cuckoo.MockManager, callMatcher: Cuckoo.CallMatcher, sourceLocation: Cuckoo.SourceLocation) {
         self.cuckoo_manager = manager
         self.callMatcher = callMatcher
         self.sourceLocation = sourceLocation

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
@@ -35,7 +35,7 @@ extension ContainerToken {
 
         return [
             "name": name,
-            "accessibility": accessibility,
+            "accessibility": accessibility.sourceName,
             "isAccessible": accessibility.isAccessible,
             "children": children.map { $0.serializeWithType() },
             "properties": properties,


### PR DESCRIPTION
It's already enforced in the tokenizer by `!`, so it should have a value and therefore there's nothing wrong with not showing it, is there?

Closes #218.