### PR TITLE
Avoid Github rate limit issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,13 @@ Method `DefaultValueRegistry.reset()` can be used to delete all value registered
 
 For normal use you can skip this because [run script](run) in Cuckoo downloads and builds correct version of the generator automatically.
 
+> If you encounter Github API rate limit.
+
+To avoid Github rate limit, [run script](run) refers to the environment variable `GITHUB_ACCESS_TOKEN`.
+```
+export GITHUB_ACCESS_TOKEN="XXXXXXX"
+```
+
 #### Custom
 
 This is more complicated path. You need to clone this repository and build it yourself. You can look in the [run script](run) for more inspiration.

--- a/run
+++ b/run
@@ -6,7 +6,11 @@ FILE_PATH="$SCRIPT_PATH/$FILE_NAME"
 GREP_OPTIONS=""
 
 function perform_curl {
-  curl -Lo ${FILE_NAME} `curl "$1" | grep -oe '"browser_download_url":\s*"[^" ]*"' | grep -oe 'http[^" ]*' | grep ${FILE_NAME} | head -1`
+  if [[ ! -z "$GITHUB_ACCESS_TOKEN" ]]; then
+		REQUEST_HEADER="-H 'Authorization: token ${GITHUB_ACCESS_TOKEN}'"
+	fi
+
+  eval curl ${REQUEST_HEADER} -Lo ${FILE_NAME} `eval curl $REQUEST_HEADER "$1" | grep -oe '"browser_download_url":\s*"[^" ]*"' | grep -oe 'http[^" ]*' | grep ${FILE_NAME} | head -1`
 }
 
 function download_generator {

--- a/run
+++ b/run
@@ -7,8 +7,8 @@ GREP_OPTIONS=""
 
 function perform_curl {
   if [[ ! -z "$GITHUB_ACCESS_TOKEN" ]]; then
-		REQUEST_HEADER="-H 'Authorization: token ${GITHUB_ACCESS_TOKEN}'"
-	fi
+    REQUEST_HEADER="-H 'Authorization: token ${GITHUB_ACCESS_TOKEN}'"
+  fi
 
   eval curl ${REQUEST_HEADER} -Lo ${FILE_NAME} `eval curl $REQUEST_HEADER "$1" | grep -oe '"browser_download_url":\s*"[^" ]*"' | grep -oe 'http[^" ]*' | grep ${FILE_NAME} | head -1`
 }


### PR DESCRIPTION
To avoid Github rate limit issues.
In shared environment(like a Circle CI), run script could hit a Github API rate limit.

If `GITHUB_ACCESS_TOKEN` is declared in the environment,
Added to curl option.