### PR TITLE
Support spaces in script path in build_generator

### DIFF
--- a/build_generator
+++ b/build_generator
@@ -3,7 +3,7 @@
 # getting the script directory: https://stackoverflow.com/a/246128
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-pushd ${DIR}/Generator
+pushd "${DIR}/Generator"
 rm -rf .build
 env -i PATH="$PATH" HOME="$HOME" swift build --configuration release -Xswiftc -static-stdlib
 popd


### PR DESCRIPTION
The ```build_generator``` script did not support spaces in the script path, and failed at the ```pushd``` command.