### PR TITLE
Add property attributes to stubs and proxies

### DIFF
--- a/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
@@ -9,6 +9,9 @@ extension Templates {
     static let noImplStub = """
 {{container.accessibility}} class {{ container.name }}Stub: {{ container.name }} {
     {% for property in container.properties %}
+    {% for attribute in property.attributes %}
+    {{ attribute.text }}
+    {% endfor %}
     {{ property.accessibility }}{% if container.@type == "ClassDeclaration" %} override{% endif %} var {{ property.name }}: {{ property.type }} {
         get {
             return DefaultValueRegistry.defaultValue(for: ({{property.type|genericSafe}}).self)

--- a/Generator/Source/CuckooGeneratorFramework/Templates/StubbingProxyTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/StubbingProxyTemplate.swift
@@ -16,6 +16,9 @@ extension Templates {
         self.cuckoo_manager = manager
     }
     {% for property in container.properties %}
+    {% for attribute in property.attributes %}
+    {{ attribute.text }}
+    {% endfor %}
     var {{property.name}}: Cuckoo.{{ property.stubType }}<{{ container.mockName }}, {{property.type|genericSafe}}> {
         return .init(manager: cuckoo_manager, name: "{{property.name}}")
     }

--- a/Generator/Source/CuckooGeneratorFramework/Templates/VerificationProxyTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/VerificationProxyTemplate.swift
@@ -21,6 +21,9 @@ extension Templates {
     }
 
     {% for property in container.properties %}
+    {% for attribute in property.attributes %}
+    {{ attribute.text }}
+    {% endfor %}
     var {{property.name}}: Cuckoo.Verify{% if property.isReadOnly %}ReadOnly{%endif%}Property<{{property.type|genericSafe}}> {
         return .init(manager: cuckoo_manager, name: "{{property.name}}", callMatcher: callMatcher, sourceLocation: sourceLocation)
     }

--- a/Tests/Source/TestedClass.swift
+++ b/Tests/Source/TestedClass.swift
@@ -10,6 +10,9 @@ import UIKit.DocumentManager  ; import Foundation
 import class UIKit.UIFont
 import UIKit
 
+@available(iOS 42.0, *)
+protocol UnavailableProtocol { }
+
 @available(swift 4.0)
 class TestedClass {
     
@@ -19,6 +22,11 @@ class TestedClass {
 
     var readOnlyProperty: String {
         return "a"
+    }
+    
+    @available(iOS 42.0, *)
+    var unavailableProperty: UnavailableProtocol? {
+        return nil
     }
     
     lazy var readWriteProperty: Int = 0


### PR DESCRIPTION
Adds property attributes to the templates of stubbing proxies, verification proxies and stubs.

For example, this is required for the following example protocol to be mockable with a deployment target lower than the iOS version specified in the `@available` attribute (suppose that `Baz` was introduced with iOS 12):

```
protocol Bar {
    
    @available(iOS 12.0, *)
    var foo: Baz? { get }
}
```

If the `@available` attribute is not included in stubs and proxies, Cuckoo's output file will not compile.