### PR TITLE
Depend on original FileKit repo to build Generator

### DIFF
--- a/Generator/Package.resolved
+++ b/Generator/Package.resolved
@@ -12,10 +12,10 @@
       },
       {
         "package": "FileKit",
-        "repositoryURL": "https://github.com/TadeasKriz/FileKit.git",
+        "repositoryURL": "https://github.com/nvzqz/FileKit.git",
         "state": {
           "branch": "develop",
-          "revision": "0acc6e7c336bbd2336c2f9670564dac9ec9c03fe",
+          "revision": "48b5ddb287f131a5c628badc819b880453f94449",
           "version": null
         }
       },

--- a/Generator/Package.swift
+++ b/Generator/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/jpsim/SourceKitten.git", .upToNextMinor(from: "0.21.2")),
-        .package(url: "https://github.com/TadeasKriz/FileKit.git", .branch("develop")),
+        .package(url: "https://github.com/nvzqz/FileKit.git", .branch("develop")),
         .package(url: "https://github.com/kylef/Stencil.git", from: "0.9.0"),
         .package(url: "https://github.com/Carthage/Commandant.git", from: "0.12.0")
         ],


### PR DESCRIPTION
The manifest file of the original FileKit repository has been updated to the 4.2 syntax. This PR updates the Generator's `Package.swift` file to point to the original FileKit repository, fixing the error reported in #264.

FileKit's updated manifest file is compatible with the Xcode toolchain from version 10.0 to 10.2.