### PR TITLE
fix curl malformed url error when no github token is passed

### DIFF
--- a/run
+++ b/run
@@ -12,9 +12,9 @@ function perform_curl {
   fi
   echo "$1"
 
-  DOWNLOAD_URL=$(curl "$REQUEST_HEADER" "$1" | grep -oe '"browser_download_url":\s*"[^" ]*"' | grep -oe 'http[^" ]*' | grep "$FILE_NAME" | head -1)
+  DOWNLOAD_URL=$(curl ${REQUEST_HEADER+"$REQUEST_HEADER"} "$1" | grep -oe '"browser_download_url":\s*"[^" ]*"' | grep -oe 'http[^" ]*' | grep "$FILE_NAME" | head -1)
   echo "$DOWNLOAD_URL"
-  curl "$REQUEST_HEADER" -Lo "$FILE_NAME" "$DOWNLOAD_URL"
+  curl ${REQUEST_HEADER+"$REQUEST_HEADER"} -Lo "$FILE_NAME" "$DOWNLOAD_URL"
 }
 
 function download_generator {


### PR DESCRIPTION
When `REQUEST_HEADER` is null, it gets expanded to `''` (double single quotes) which causes curl to throw an error: `curl: (3) <url> malformed`.

On my macOS Mojave machine this causes a lot of problems. The second invocation of curl in the `run` script outputs the whole binary to stderr and dumps all that garbage to my screen.

This patch does the variable expansion "only if the variable is defined" and is [supported by all bash shells](http://mywiki.wooledge.org/BashFAQ/073).