### PR TITLE
Change build_generator to work with Swift 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: objective-c
-osx_image: xcode9
+osx_image: xcode10.2
 xcode_project: Cuckoo.xcodeproj
 xcode_scheme: Cuckoo
 xcode_sdk: macosx
 
 before_script:
-    - gem install cucumber --no-rdoc --no-ri
-    - gem install aruba --no-rdoc --no-ri
+    - gem install cucumber --no-document 
+    - gem install aruba --no-document 
 
 script:
     - pushd Generator

--- a/build_generator
+++ b/build_generator
@@ -5,5 +5,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 pushd "${DIR}/Generator"
 rm -rf .build
-env -i PATH="$PATH" HOME="$HOME" swift build --configuration release -Xswiftc -static-stdlib
+env -i PATH="$PATH" HOME="$HOME" swift build --configuration release --static-swift-stdlib
 popd


### PR DESCRIPTION
The current `build_generator` script which executes `swift build` command to generator the `cuckoo_generator` doesn't work with Swift 5 so the new command line `swift build --configuration release --static-swift-stdlib` is enough to build the `cuckoo_generator` and also keep it distributable.