### PR TITLE
Add tests for stubbing optional read only properties.

### DIFF
--- a/Tests/ClassTest.swift
+++ b/Tests/ClassTest.swift
@@ -45,6 +45,28 @@ class ClassTest: XCTestCase {
         verify(mock).readOnlyProperty.get()
     }
 
+    func testOptionalReadOnlyProperty() {
+        let mock = MockTestedClass()
+
+        stub(mock) { mock in
+            when(mock.optionalReadOnlyProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.optionalReadOnlyProperty, "a")
+        verify(mock).optionalReadOnlyProperty.get()
+    }
+
+    func testOptionalReadOnlyPropertyIsNil() {
+        let mock = MockTestedClass()
+
+        stub(mock) { mock in
+            when(mock.optionalReadOnlyProperty.get).thenReturn(nil)
+        }
+
+        XCTAssertNil(mock.optionalReadOnlyProperty)
+        verify(mock).optionalReadOnlyProperty.get()
+    }
+
     func testReadWriteProperty() {
         var called = false
         stub(mock) { mock in

--- a/Tests/Source/TestedClass.swift
+++ b/Tests/Source/TestedClass.swift
@@ -22,6 +22,10 @@ class TestedClass {
         return "a"
     }
 
+    var optionalReadOnlyProperty: String? {
+        return "a"
+    }
+
     @available(iOS 42.0, *)
     var unavailableProperty: UnavailableProtocol? {
         return nil


### PR DESCRIPTION
Tests for stubbing a readOnly-Property that is optional.

The nil-case fails compiling while the value-case fails with a missing stub.