### PR TITLE
Convenience matchers for `Array`, `Dictionary`, and `Set` types.

### DIFF
--- a/Cuckoo.xcodeproj/project.pbxproj
+++ b/Cuckoo.xcodeproj/project.pbxproj
@@ -157,6 +157,10 @@
 		685D69A12320043C00250BF2 /* Dictionary+matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D699F2320043C00250BF2 /* Dictionary+matchers.swift */; };
 		685D69A32320044400250BF2 /* Set+matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D69A22320044400250BF2 /* Set+matchers.swift */; };
 		685D69A42320044400250BF2 /* Set+matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D69A22320044400250BF2 /* Set+matchers.swift */; };
+		685D69A62320FEC100250BF2 /* Array+matchersTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D69A52320FEC100250BF2 /* Array+matchersTest.swift */; };
+		685D69A72320FEC100250BF2 /* Array+matchersTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D69A52320FEC100250BF2 /* Array+matchersTest.swift */; };
+		685D69A92321498D00250BF2 /* Dictionary+matchersTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D69A82321498D00250BF2 /* Dictionary+matchersTest.swift */; };
+		685D69AA2321498D00250BF2 /* Dictionary+matchersTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D69A82321498D00250BF2 /* Dictionary+matchersTest.swift */; };
 		6861B32921A31DAC002EC2DA /* GenericClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6861B30B21A31DA2002EC2DA /* GenericClass.swift */; };
 		6861B32A21A31DAD002EC2DA /* GenericClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6861B30B21A31DA2002EC2DA /* GenericClass.swift */; };
 		6861B32C21A32279002EC2DA /* GenericProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6861B32B21A32279002EC2DA /* GenericProtocol.swift */; };
@@ -370,6 +374,8 @@
 		685D699C2320043200250BF2 /* Array+matchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+matchers.swift"; sourceTree = "<group>"; };
 		685D699F2320043C00250BF2 /* Dictionary+matchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+matchers.swift"; sourceTree = "<group>"; };
 		685D69A22320044400250BF2 /* Set+matchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+matchers.swift"; sourceTree = "<group>"; };
+		685D69A52320FEC100250BF2 /* Array+matchersTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+matchersTest.swift"; sourceTree = "<group>"; };
+		685D69A82321498D00250BF2 /* Dictionary+matchersTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+matchersTest.swift"; sourceTree = "<group>"; };
 		6861B30B21A31DA2002EC2DA /* GenericClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericClass.swift; sourceTree = "<group>"; };
 		6861B32B21A32279002EC2DA /* GenericProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericProtocol.swift; sourceTree = "<group>"; };
 		6896352D21AC5A4700B25D47 /* GenericProtocolTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericProtocolTest.swift; sourceTree = "<group>"; };
@@ -585,6 +591,8 @@
 				18E2A26A1FBB1C330058FEC5 /* MatchableTest.swift */,
 				18E2A26B1FBB1C330058FEC5 /* ParameterMatcherFunctionsTest.swift */,
 				18E2A26C1FBB1C330058FEC5 /* ParameterMatcherTest.swift */,
+				685D69A52320FEC100250BF2 /* Array+matchersTest.swift */,
+				685D69A82321498D00250BF2 /* Dictionary+matchersTest.swift */,
 			);
 			path = Matching;
 			sourceTree = "<group>";
@@ -996,6 +1004,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				685D69A92321498D00250BF2 /* Dictionary+matchersTest.swift in Sources */,
 				18E2A31C1FBB23550058FEC5 /* StubbingProxy.swift in Sources */,
 				18E2A3321FBB31250058FEC5 /* VerifyProperty.swift in Sources */,
 				685D699D2320043200250BF2 /* Array+matchers.swift in Sources */,
@@ -1003,6 +1012,7 @@
 				18E2A31D1FBB23550058FEC5 /* VerificationProxy.swift in Sources */,
 				18E2A3281FBB235A0058FEC5 /* ParameterMatcherFunctions.swift in Sources */,
 				18E2A3151FBB234F0058FEC5 /* StubAction.swift in Sources */,
+				685D69A62320FEC100250BF2 /* Array+matchersTest.swift in Sources */,
 				685D69A02320043C00250BF2 /* Dictionary+matchers.swift in Sources */,
 				18E2A3331FBB31250058FEC5 /* VerifyReadOnlyProperty.swift in Sources */,
 				18E2A3371FBB31290058FEC5 /* ArgumentCaptor.swift in Sources */,
@@ -1043,6 +1053,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				685D69AA2321498D00250BF2 /* Dictionary+matchersTest.swift in Sources */,
 				18E2A3181FBB23540058FEC5 /* StubbingProxy.swift in Sources */,
 				18E2A3301FBB31240058FEC5 /* VerifyProperty.swift in Sources */,
 				685D699E2320043200250BF2 /* Array+matchers.swift in Sources */,
@@ -1050,6 +1061,7 @@
 				18E2A3191FBB23540058FEC5 /* VerificationProxy.swift in Sources */,
 				18E2A3231FBB23590058FEC5 /* ParameterMatcherFunctions.swift in Sources */,
 				18E2A3121FBB234E0058FEC5 /* StubAction.swift in Sources */,
+				685D69A72320FEC100250BF2 /* Array+matchersTest.swift in Sources */,
 				685D69A12320043C00250BF2 /* Dictionary+matchers.swift in Sources */,
 				18E2A3311FBB31240058FEC5 /* VerifyReadOnlyProperty.swift in Sources */,
 				18E2A3351FBB31280058FEC5 /* ArgumentCaptor.swift in Sources */,

--- a/Cuckoo.xcodeproj/project.pbxproj
+++ b/Cuckoo.xcodeproj/project.pbxproj
@@ -151,6 +151,12 @@
 		682D2891228B10970078DDCD /* GenericMethodClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682D288F228B10970078DDCD /* GenericMethodClassTest.swift */; };
 		682D2893228B183E0078DDCD /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682D2892228B183E0078DDCD /* TestError.swift */; };
 		682D2894228B183E0078DDCD /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682D2892228B183E0078DDCD /* TestError.swift */; };
+		685D699D2320043200250BF2 /* Array+matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D699C2320043200250BF2 /* Array+matchers.swift */; };
+		685D699E2320043200250BF2 /* Array+matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D699C2320043200250BF2 /* Array+matchers.swift */; };
+		685D69A02320043C00250BF2 /* Dictionary+matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D699F2320043C00250BF2 /* Dictionary+matchers.swift */; };
+		685D69A12320043C00250BF2 /* Dictionary+matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D699F2320043C00250BF2 /* Dictionary+matchers.swift */; };
+		685D69A32320044400250BF2 /* Set+matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D69A22320044400250BF2 /* Set+matchers.swift */; };
+		685D69A42320044400250BF2 /* Set+matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 685D69A22320044400250BF2 /* Set+matchers.swift */; };
 		6861B32921A31DAC002EC2DA /* GenericClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6861B30B21A31DA2002EC2DA /* GenericClass.swift */; };
 		6861B32A21A31DAD002EC2DA /* GenericClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6861B30B21A31DA2002EC2DA /* GenericClass.swift */; };
 		6861B32C21A32279002EC2DA /* GenericProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6861B32B21A32279002EC2DA /* GenericProtocol.swift */; };
@@ -361,6 +367,9 @@
 		682D2836228AE0E10078DDCD /* GenericMethodClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericMethodClass.swift; sourceTree = "<group>"; };
 		682D288F228B10970078DDCD /* GenericMethodClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericMethodClassTest.swift; sourceTree = "<group>"; };
 		682D2892228B183E0078DDCD /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
+		685D699C2320043200250BF2 /* Array+matchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+matchers.swift"; sourceTree = "<group>"; };
+		685D699F2320043C00250BF2 /* Dictionary+matchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+matchers.swift"; sourceTree = "<group>"; };
+		685D69A22320044400250BF2 /* Set+matchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+matchers.swift"; sourceTree = "<group>"; };
 		6861B30B21A31DA2002EC2DA /* GenericClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericClass.swift; sourceTree = "<group>"; };
 		6861B32B21A32279002EC2DA /* GenericProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericProtocol.swift; sourceTree = "<group>"; };
 		6896352D21AC5A4700B25D47 /* GenericProtocolTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericProtocolTest.swift; sourceTree = "<group>"; };
@@ -450,6 +459,9 @@
 				18E2A23D1FBB1C330058FEC5 /* Matchable.swift */,
 				18E2A23E1FBB1C330058FEC5 /* ParameterMatcher.swift */,
 				18E2A23F1FBB1C330058FEC5 /* ParameterMatcherFunctions.swift */,
+				685D699C2320043200250BF2 /* Array+matchers.swift */,
+				685D699F2320043C00250BF2 /* Dictionary+matchers.swift */,
+				685D69A22320044400250BF2 /* Set+matchers.swift */,
 			);
 			path = Matching;
 			sourceTree = "<group>";
@@ -986,10 +998,12 @@
 			files = (
 				18E2A31C1FBB23550058FEC5 /* StubbingProxy.swift in Sources */,
 				18E2A3321FBB31250058FEC5 /* VerifyProperty.swift in Sources */,
+				685D699D2320043200250BF2 /* Array+matchers.swift in Sources */,
 				18E2A2FB1FBB23420058FEC5 /* ToBeStubbedReadOnlyProperty.swift in Sources */,
 				18E2A31D1FBB23550058FEC5 /* VerificationProxy.swift in Sources */,
 				18E2A3281FBB235A0058FEC5 /* ParameterMatcherFunctions.swift in Sources */,
 				18E2A3151FBB234F0058FEC5 /* StubAction.swift in Sources */,
+				685D69A02320043C00250BF2 /* Dictionary+matchers.swift in Sources */,
 				18E2A3331FBB31250058FEC5 /* VerifyReadOnlyProperty.swift in Sources */,
 				18E2A3371FBB31290058FEC5 /* ArgumentCaptor.swift in Sources */,
 				18E2A3031FBB23480058FEC5 /* BaseStubFunctionTrait.swift in Sources */,
@@ -1001,6 +1015,7 @@
 				18E2A2FA1FBB23420058FEC5 /* ToBeStubbedProperty.swift in Sources */,
 				68E9EAE6224B9F34000DBD29 /* StubFunctionThenThrowingTrait.swift in Sources */,
 				18E2A31B1FBB23550058FEC5 /* Mock.swift in Sources */,
+				685D69A32320044400250BF2 /* Set+matchers.swift in Sources */,
 				18E2A3071FBB23480058FEC5 /* StubFunctionThenThrowTrait.swift in Sources */,
 				18E2A3101FBB234B0058FEC5 /* StubThrowingFunction.swift in Sources */,
 				18E2A30E1FBB234B0058FEC5 /* StubNoReturnFunction.swift in Sources */,
@@ -1030,10 +1045,12 @@
 			files = (
 				18E2A3181FBB23540058FEC5 /* StubbingProxy.swift in Sources */,
 				18E2A3301FBB31240058FEC5 /* VerifyProperty.swift in Sources */,
+				685D699E2320043200250BF2 /* Array+matchers.swift in Sources */,
 				18E2A2F81FBB23410058FEC5 /* ToBeStubbedReadOnlyProperty.swift in Sources */,
 				18E2A3191FBB23540058FEC5 /* VerificationProxy.swift in Sources */,
 				18E2A3231FBB23590058FEC5 /* ParameterMatcherFunctions.swift in Sources */,
 				18E2A3121FBB234E0058FEC5 /* StubAction.swift in Sources */,
+				685D69A12320043C00250BF2 /* Dictionary+matchers.swift in Sources */,
 				18E2A3311FBB31240058FEC5 /* VerifyReadOnlyProperty.swift in Sources */,
 				18E2A3351FBB31280058FEC5 /* ArgumentCaptor.swift in Sources */,
 				18E2A2FD1FBB23470058FEC5 /* BaseStubFunctionTrait.swift in Sources */,
@@ -1045,6 +1062,7 @@
 				18E2A2F71FBB23410058FEC5 /* ToBeStubbedProperty.swift in Sources */,
 				68E9EAFF224BA4B4000DBD29 /* StubFunctionThenThrowingTrait.swift in Sources */,
 				18E2A3171FBB23540058FEC5 /* Mock.swift in Sources */,
+				685D69A42320044400250BF2 /* Set+matchers.swift in Sources */,
 				18E2A3011FBB23470058FEC5 /* StubFunctionThenThrowTrait.swift in Sources */,
 				18E2A30C1FBB234B0058FEC5 /* StubThrowingFunction.swift in Sources */,
 				18E2A30A1FBB234B0058FEC5 /* StubNoReturnFunction.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ These basic values are extended to conform to `Matchable`:
 - `UInt32`
 - `UInt64`
 
+Matchers for `Array`, `Dictionary`, and `Set` are automatically synthesised as long as the type of the element conforms to `Matchable`.
+
 #### B) Custom matchers
 If Cuckoo doesn't know the type you are trying to compare, you have to write your own method `equal(to:)` using a `ParameterMatcher`. Add this method to your test file:
 
@@ -328,6 +330,8 @@ anyThrowingClosure()
 /// Returns a matcher matching any non nil value.
 notNil()
 ```
+
+Cuckoo also provides plenty of convenience matchers for sequences and dictionaries, allowing you to check if a sequence is a superset of a certain sequence, contains at least one of its elements, or is completely disjunct from it.
 
 `Matchable` can be chained with methods `or` and `and` like so:
 

--- a/Source/Matching/Array+matchers.swift
+++ b/Source/Matching/Array+matchers.swift
@@ -18,9 +18,21 @@ extension Array: Matchable where Element: Matchable, Element == Element.MatchedT
 
 
 // MARK: Contains ANY of the elements.
-public func containsAnyOf<T>(values elements: T..., where equality: @escaping (T, T) -> Bool) -> ParameterMatcher<[T]> {
+/**
+ * Matcher for sequences of elements that checks if at least one of the passed elements matches the passed sequence.
+ * - parameter values: Variadic elements that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
+public func containsAnyOf<T, S: Sequence>(values elements: T..., where equality: @escaping (T, T) -> Bool) -> ParameterMatcher<S> where T == S.Element {
     return containsAnyOf(elements, where: equality)
 }
+/**
+ * Matcher for sequences of elements that checks if at least one of the passed elements matches the passed sequence.
+ * - parameter elements: Elements that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAnyOf<IN: Sequence, OUT: Sequence>(_ elements: IN, where equality: @escaping (IN.Element, IN.Element) -> Bool) -> ParameterMatcher<OUT> where IN.Element == OUT.Element {
     return ParameterMatcher { sequence in
         elements.contains { element in
@@ -31,16 +43,36 @@ public func containsAnyOf<IN: Sequence, OUT: Sequence>(_ elements: IN, where equ
     }
 }
 
-public func containsAnyOf<T: Equatable>(values elements: T...) -> ParameterMatcher<[T]> {
+/**
+ * Matcher for sequences of `Equatable` elements that checks if at least one of the passed elements matches the passed sequence.
+ * - parameter values: Variadic elements that are used for matching.
+ * - returns: ParameterMatcher object.
+ */
+public func containsAnyOf<T: Equatable, S: Sequence>(values elements: T...) -> ParameterMatcher<S> where T == S.Element {
     return containsAnyOf(elements)
 }
+/**
+ * Matcher for sequences of `Equatable` elements that checks if at least one of the passed elements matches the passed sequence.
+ * - parameter elements: Elements that are used for matching.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAnyOf<IN: Sequence, OUT: Sequence>(_ elements: IN) -> ParameterMatcher<OUT> where IN.Element: Equatable, IN.Element == OUT.Element {
     return containsAnyOf(elements, where: ==)
 }
 
-public func containsAnyOf<T: Hashable>(values elements: T...) -> ParameterMatcher<[T]> {
+/**
+ * Matcher for sequences of `Hashable` elements that checks if at least one of the passed elements matches the passed sequence.
+ * - parameter values: Variadic elements that are used for matching.
+ * - returns: ParameterMatcher object.
+ */
+public func containsAnyOf<T: Hashable, S: Sequence>(values elements: T...) -> ParameterMatcher<S> where T == S.Element {
     return containsAnyOf(elements)
 }
+/**
+ * Matcher for sequences of `Hashable` elements that checks if at least one of the passed elements matches the passed sequence.
+ * - parameter elements: Elements that are used for matching.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAnyOf<IN: Sequence, OUT: Sequence>(_ elements: IN) -> ParameterMatcher<OUT> where IN.Element: Hashable, IN.Element == OUT.Element {
     return ParameterMatcher { sequence in
         let set = Set(sequence)
@@ -51,30 +83,91 @@ public func containsAnyOf<IN: Sequence, OUT: Sequence>(_ elements: IN) -> Parame
 
 
 // MARK: Contains ALL of the elements.
-public func containsAllOf<T>(values elements: T..., where equality: @escaping (T, T) -> Bool) -> ParameterMatcher<[T]> {
+/**
+ * Matcher for sequences of elements that checks if all of the passed elements match the passed sequence.
+ * - parameter values: Variadic elements that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ * - NOTE: When matching an Array, this matcher expects items as many times as they are present in the passed elements.
+ */
+public func containsAllOf<T, S: Sequence>(values elements: T..., where equality: @escaping (T, T) -> Bool) -> ParameterMatcher<S> where T == S.Element {
     return containsAllOf(elements, where: equality)
 }
+/**
+ * Matcher for sequences of elements that checks if all of the passed elements match the passed sequence.
+ * - parameter elements: Elements that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ * - NOTE: When passing an Array, this matcher expects items as many times as they are present in the passed elements.
+ */
 public func containsAllOf<IN: Sequence, OUT: Sequence>(_ elements: IN, where equality: @escaping (IN.Element, IN.Element) -> Bool) -> ParameterMatcher<OUT> where IN.Element == OUT.Element {
     return ParameterMatcher { sequence in
-        elements.allSatisfy { element in
-            sequence.contains {
-                equality($0, element)
+        var matchedSequence = sequence.map { (element: $0, matched: false) }
+        for element in elements {
+            if let matchedIndex = matchedSequence.firstIndex(where: { !$0.matched && equality($0.element, element) }) {
+                matchedSequence[matchedIndex].matched = true
+            } else {
+                return false
             }
         }
+        return true
     }
 }
 
-public func containsAllOf<T: Equatable>(values elements: T...) -> ParameterMatcher<[T]> {
+/**
+ * Matcher for sequences of `Equatable` elements that checks if all of the passed elements match the passed sequence.
+ * - parameter values: Variadic elements that are used for matching.
+ * - returns: ParameterMatcher object.
+ * - NOTE: When passing an Array, this matcher expects items as many times as they are present in the passed elements.
+ */
+public func containsAllOf<T: Equatable, S: Sequence>(values elements: T...) -> ParameterMatcher<S> where T == S.Element {
     return containsAllOf(elements)
 }
+/**
+ * Matcher for sequences of `Equatable` elements that checks if all of the passed elements match the passed sequence.
+ * - parameter elements: Elements that are used for matching.
+ * - returns: ParameterMatcher object.
+ * - NOTE: When passing an Array, this matcher expects items as many times as they are present in the passed elements.
+ */
 public func containsAllOf<IN: Sequence, OUT: Sequence>(_ elements: IN) -> ParameterMatcher<OUT> where IN.Element: Equatable, IN.Element == OUT.Element {
     return containsAllOf(elements, where: ==)
 }
 
+/**
+ * Matcher for sequences of `Hashable` elements that checks if all of the passed elements match the passed sequence.
+ * - parameter values: Variadic elements that are used for matching.
+ * - returns: ParameterMatcher object.
+ * - NOTE: When passing an Array, this matcher expects items as many times as they are present in the passed elements.
+ */
 public func containsAllOf<T: Hashable>(values elements: T...) -> ParameterMatcher<[T]> {
     return containsAllOf(elements)
 }
+/**
+ * Matcher for sequences of `Hashable` elements that checks if all of the passed elements match the passed sequence.
+ * - parameter elements: Elements that are used for matching.
+ * - returns: ParameterMatcher object.
+ * - NOTE: When passing an Array, this matcher expects items as many times as they are present in the passed elements.
+ */
 public func containsAllOf<IN: Sequence, OUT: Sequence>(_ elements: IN) -> ParameterMatcher<OUT> where IN.Element: Hashable, IN.Element == OUT.Element {
+    return ParameterMatcher { sequence in
+        let sequenceDictionary: [IN.Element: Int] = sequence.reduce(into: [:]) { dictionary, element in
+            dictionary[element, default: 0] += 1
+        }
+        let elementsDictionary: [IN.Element: Int] = elements.reduce(into: [:]) { dictionary, element in
+            dictionary[element, default: 0] += 1
+        }
+
+        return elementsDictionary.allSatisfy { key, element in
+            sequenceDictionary[key].map { $0 == element } ?? false
+        }
+    }
+}
+/**
+ * Matcher for `Set`s of `Hashable` elements that checks if all of the passed elements match the passed `Set`.
+ * - parameter elements: Elements that are used for matching.
+ * - returns: ParameterMatcher object.
+ */
+public func containsAllOf<IN: Sequence, OUT: Sequence>(_ elements: IN) -> ParameterMatcher<OUT> where IN.Element: Hashable, IN.Element == OUT.Element, IN: SetAlgebra {
     return ParameterMatcher { sequence in
         let set = Set(sequence)
         let elementsSet = Set(elements)
@@ -84,44 +177,107 @@ public func containsAllOf<IN: Sequence, OUT: Sequence>(_ elements: IN) -> Parame
 
 
 // MARK: Contains NONE of the elements.
-public func containsNoneOf<T>(values elements: T..., where equality: @escaping (T, T) -> Bool) -> ParameterMatcher<[T]> {
+/**
+ * Matcher for sequences of elements that checks if none of the passed elements match the passed sequence.
+ * - parameter values: Variadic elements that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
+public func containsNoneOf<T, S: Sequence>(values elements: T..., where equality: @escaping (T, T) -> Bool) -> ParameterMatcher<S> where T == S.Element {
     return containsNoneOf(elements, where: equality)
 }
+/**
+ * Matcher for sequences of elements that checks if none of the passed elements match the passed sequence.
+ * - parameter elements: Elements that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsNoneOf<IN: Sequence, OUT: Sequence>(_ elements: IN, where equality: @escaping (IN.Element, IN.Element) -> Bool) -> ParameterMatcher<OUT> where IN.Element == OUT.Element {
     return not(containsAnyOf(elements, where: equality))
 }
 
-public func containsNoneOf<T: Equatable>(values elements: T...) -> ParameterMatcher<[T]> {
+/**
+ * Matcher for sequences of `Equatable` elements that checks if none of the passed elements match the passed sequence.
+ * - parameter values: Variadic elements that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
+public func containsNoneOf<T: Equatable, S: Sequence>(values elements: T...) -> ParameterMatcher<S> where T == S.Element {
     return containsNoneOf(elements)
 }
+/**
+ * Matcher for sequences of `Equatable` elements that checks if none of the passed elements match the passed sequence.
+ * - parameter elements: Elements that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsNoneOf<IN: Sequence, OUT: Sequence>(_ elements: IN) -> ParameterMatcher<OUT> where IN.Element: Equatable, IN.Element == OUT.Element {
     return containsNoneOf(elements, where: ==)
 }
 
-public func containsNoneOf<T: Hashable>(values elements: T...) -> ParameterMatcher<[T]> {
+/**
+ * Matcher for sequences of `Hashable` elements that checks if none of the passed elements match the passed sequence.
+ * - parameter values: Variadic elements that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
+public func containsNoneOf<T: Hashable, S: Sequence>(values elements: T...) -> ParameterMatcher<S> where T == S.Element {
     return containsNoneOf(elements)
 }
+/**
+ * Matcher for sequences of `Hashable` elements that checks if none of the passed elements match the passed sequence.
+ * - parameter elements: Elements that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsNoneOf<IN: Sequence, OUT: Sequence>(_ elements: IN) -> ParameterMatcher<OUT> where IN.Element: Hashable, IN.Element == OUT.Element {
     return not(containsAnyOf(elements))
 }
 
 
-
 // MARK: Has length N (exact, at least, at most).
+/**
+ * Matcher for collections of elements that checks if the collection is exactly N elements long.
+ * - parameter exactly: Required length of the matching collection.
+ * - returns: ParameterMatcher object.
+ */
 public func hasLength<C: Collection>(exactly requiredExactLength: Int) -> ParameterMatcher<C> {
     return ParameterMatcher { collection in
         collection.count == requiredExactLength
     }
 }
 
+/**
+ * Matcher for collections of elements that checks if the collection is at least N elements long with the option to include the number itself (default).
+ * - parameter atLeast: Required minimum length of the matching collection.
+ * - parameter inclusive: Whether the minimum length itself should be included.
+ * - returns: ParameterMatcher object.
+ */
 public func hasLength<C: Collection>(atLeast requiredMinimumLength: Int, inclusive: Bool = true) -> ParameterMatcher<C> {
     return ParameterMatcher { collection in
         collection.count > requiredMinimumLength || (inclusive && collection.count == requiredMinimumLength)
     }
 }
 
+/**
+ * Matcher for collections of elements that checks if the collection is at most N elements long with the option to include the number itself (default).
+ * - parameter atMost: Required maximum length of the matching collection.
+ * - parameter inclusive: Whether the maximum length itself should be included.
+ * - returns: ParameterMatcher object.
+ */
 public func hasLength<C: Collection>(atMost requiredMaximumLength: Int, inclusive: Bool = true) -> ParameterMatcher<C> {
     return ParameterMatcher { collection in
         collection.count < requiredMaximumLength || (inclusive && collection.count == requiredMaximumLength)
     }
+}
+
+/**
+ * Matcher for collections of elements that checks if the collection is at between N and M elements long with the option to include the bounds as well (default).
+ * - parameter inRange: Required length range of the matching collection.
+ * - parameter inclusive: Whether the length range bounds should be included.
+ * - returns: ParameterMatcher object.
+ */
+public func hasLength<C: Collection>(inRange requiredLengthRange: CountableRange<Int>, inclusive: Bool = true) -> ParameterMatcher<C> {
+    return hasLength(atLeast: requiredLengthRange.lowerBound, inclusive: inclusive)
+        .and(hasLength(atMost: requiredLengthRange.upperBound, inclusive: inclusive))
 }

--- a/Source/Matching/Array+matchers.swift
+++ b/Source/Matching/Array+matchers.swift
@@ -1,0 +1,17 @@
+//
+//  Array+matchers.swift
+//  Cuckoo
+//
+//  Created by Matyáš Kříž on 04/09/2019.
+//
+
+extension Array: Matchable where Element: Matchable, Element == Element.MatchedType {
+    public typealias MatchedType = [Element]
+
+    public var matcher: ParameterMatcher<[Element]> {
+        return ParameterMatcher<[Element]> { other in
+            guard self.count == other.count else { return false }
+            return zip(self, other).allSatisfy { $0.matcher.matches($1) }
+        }
+    }
+}

--- a/Source/Matching/Array+matchers.swift
+++ b/Source/Matching/Array+matchers.swift
@@ -15,3 +15,113 @@ extension Array: Matchable where Element: Matchable, Element == Element.MatchedT
         }
     }
 }
+
+
+// MARK: Contains ANY of the elements.
+public func containsAnyOf<T>(values elements: T..., where equality: @escaping (T, T) -> Bool) -> ParameterMatcher<[T]> {
+    return containsAnyOf(elements, where: equality)
+}
+public func containsAnyOf<IN: Sequence, OUT: Sequence>(_ elements: IN, where equality: @escaping (IN.Element, IN.Element) -> Bool) -> ParameterMatcher<OUT> where IN.Element == OUT.Element {
+    return ParameterMatcher { sequence in
+        elements.contains { element in
+            sequence.contains {
+                equality($0, element)
+            }
+        }
+    }
+}
+
+public func containsAnyOf<T: Equatable>(values elements: T...) -> ParameterMatcher<[T]> {
+    return containsAnyOf(elements)
+}
+public func containsAnyOf<IN: Sequence, OUT: Sequence>(_ elements: IN) -> ParameterMatcher<OUT> where IN.Element: Equatable, IN.Element == OUT.Element {
+    return containsAnyOf(elements, where: ==)
+}
+
+public func containsAnyOf<T: Hashable>(values elements: T...) -> ParameterMatcher<[T]> {
+    return containsAnyOf(elements)
+}
+public func containsAnyOf<IN: Sequence, OUT: Sequence>(_ elements: IN) -> ParameterMatcher<OUT> where IN.Element: Hashable, IN.Element == OUT.Element {
+    return ParameterMatcher { sequence in
+        let set = Set(sequence)
+        let elementsSet = Set(elements)
+        return !set.isDisjoint(with: elementsSet)
+    }
+}
+
+
+// MARK: Contains ALL of the elements.
+public func containsAllOf<T>(values elements: T..., where equality: @escaping (T, T) -> Bool) -> ParameterMatcher<[T]> {
+    return containsAllOf(elements, where: equality)
+}
+public func containsAllOf<IN: Sequence, OUT: Sequence>(_ elements: IN, where equality: @escaping (IN.Element, IN.Element) -> Bool) -> ParameterMatcher<OUT> where IN.Element == OUT.Element {
+    return ParameterMatcher { sequence in
+        elements.allSatisfy { element in
+            sequence.contains {
+                equality($0, element)
+            }
+        }
+    }
+}
+
+public func containsAllOf<T: Equatable>(values elements: T...) -> ParameterMatcher<[T]> {
+    return containsAllOf(elements)
+}
+public func containsAllOf<IN: Sequence, OUT: Sequence>(_ elements: IN) -> ParameterMatcher<OUT> where IN.Element: Equatable, IN.Element == OUT.Element {
+    return containsAllOf(elements, where: ==)
+}
+
+public func containsAllOf<T: Hashable>(values elements: T...) -> ParameterMatcher<[T]> {
+    return containsAllOf(elements)
+}
+public func containsAllOf<IN: Sequence, OUT: Sequence>(_ elements: IN) -> ParameterMatcher<OUT> where IN.Element: Hashable, IN.Element == OUT.Element {
+    return ParameterMatcher { sequence in
+        let set = Set(sequence)
+        let elementsSet = Set(elements)
+        return set.isSuperset(of: elementsSet)
+    }
+}
+
+
+// MARK: Contains NONE of the elements.
+public func containsNoneOf<T>(values elements: T..., where equality: @escaping (T, T) -> Bool) -> ParameterMatcher<[T]> {
+    return containsNoneOf(elements, where: equality)
+}
+public func containsNoneOf<IN: Sequence, OUT: Sequence>(_ elements: IN, where equality: @escaping (IN.Element, IN.Element) -> Bool) -> ParameterMatcher<OUT> where IN.Element == OUT.Element {
+    return not(containsAnyOf(elements, where: equality))
+}
+
+public func containsNoneOf<T: Equatable>(values elements: T...) -> ParameterMatcher<[T]> {
+    return containsNoneOf(elements)
+}
+public func containsNoneOf<IN: Sequence, OUT: Sequence>(_ elements: IN) -> ParameterMatcher<OUT> where IN.Element: Equatable, IN.Element == OUT.Element {
+    return containsNoneOf(elements, where: ==)
+}
+
+public func containsNoneOf<T: Hashable>(values elements: T...) -> ParameterMatcher<[T]> {
+    return containsNoneOf(elements)
+}
+public func containsNoneOf<IN: Sequence, OUT: Sequence>(_ elements: IN) -> ParameterMatcher<OUT> where IN.Element: Hashable, IN.Element == OUT.Element {
+    return not(containsAnyOf(elements))
+}
+
+
+
+// MARK: Has length N (exact, at least, at most).
+public func hasLength<C: Collection>(exactly requiredExactLength: Int) -> ParameterMatcher<C> {
+    return ParameterMatcher { collection in
+        collection.count == requiredExactLength
+    }
+}
+
+public func hasLength<C: Collection>(atLeast requiredMinimumLength: Int, inclusive: Bool = true) -> ParameterMatcher<C> {
+    return ParameterMatcher { collection in
+        collection.count > requiredMinimumLength || (inclusive && collection.count == requiredMinimumLength)
+    }
+}
+
+public func hasLength<C: Collection>(atMost requiredMaximumLength: Int, inclusive: Bool = true) -> ParameterMatcher<C> {
+    return ParameterMatcher { collection in
+        collection.count < requiredMaximumLength || (inclusive && collection.count == requiredMaximumLength)
+    }
+}

--- a/Source/Matching/Dictionary+matchers.swift
+++ b/Source/Matching/Dictionary+matchers.swift
@@ -1,0 +1,20 @@
+//
+//  Dictionary+matchers.swift
+//  Cuckoo
+//
+//  Created by Matyáš Kříž on 04/09/2019.
+//
+
+extension Dictionary: Matchable where Value: Matchable, Value == Value.MatchedType {
+    public typealias MatchedType = [Key: Value]
+
+    public var matcher: ParameterMatcher<[Key: Value]> {
+        return ParameterMatcher<[Key: Value]> { other in
+            guard self.count == other.count else { return false }
+            return self.allSatisfy {
+                guard let foundElement = other[$0.key] else { return false }
+                return $0.value.matcher.matches(foundElement)
+            }
+        }
+    }
+}

--- a/Source/Matching/Dictionary+matchers.swift
+++ b/Source/Matching/Dictionary+matchers.swift
@@ -18,3 +18,143 @@ extension Dictionary: Matchable where Value: Matchable, Value == Value.MatchedTy
         }
     }
 }
+
+
+// MARK: PAIR MATCHING
+// MARK: Contains ANY of the elements as key-value pairs.
+public func containsAnyOf<K, V: Equatable>(_ inputDictionary: [K: V]) -> ParameterMatcher<[K: V]> {
+    return containsAnyOf(inputDictionary, where: ==)
+}
+public func containsAnyOf<K, V>(_ inputDictionary: [K: V], where equality: @escaping (V, V) -> Bool) -> ParameterMatcher<[K: V]> {
+    return ParameterMatcher { dictionary in
+        inputDictionary.contains { key, value in
+            dictionary[key].map { equality($0, value) } ?? false
+        }
+    }
+}
+
+// MARK: Contains ALL of the elements as key-value pairs.
+public func containsAllOf<K, V: Equatable>(_ inputDictionary: [K: V]) -> ParameterMatcher<[K: V]> {
+    return containsAllOf(inputDictionary, where: ==)
+}
+public func containsAllOf<K, V>(_ inputDictionary: [K: V], where equality: @escaping (V, V) -> Bool) -> ParameterMatcher<[K: V]> {
+    return ParameterMatcher { dictionary in
+        inputDictionary.allSatisfy { key, value in
+            dictionary[key].map { equality($0, value) } ?? false
+        }
+    }
+}
+
+// MARK: Contains NONE of the elements as key-value pairs.
+public func containsNoneOf<K, V: Equatable>(_ inputDictionary: [K: V]) -> ParameterMatcher<[K: V]> {
+    return containsNoneOf(inputDictionary, where: ==)
+}
+public func containsNoneOf<K, V>(_ inputDictionary: [K: V], where equality: @escaping (V, V) -> Bool) -> ParameterMatcher<[K: V]> {
+    return not(containsAnyOf(inputDictionary, where: equality))
+}
+
+
+// MARK: KEYS MATCHING
+// MARK: Contains ANY of the elements as keys.
+public func containsAnyKeysOf<K, V>(values elements: K...) -> ParameterMatcher<[K: V]> {
+    return containsAnyKeysOf(elements)
+}
+public func containsAnyKeysOf<S: Sequence, V>(_ elements: S) -> ParameterMatcher<[S.Element: V]> {
+    return ParameterMatcher { dictionary in
+        containsAnyOf(elements).matches(dictionary.keys)
+    }
+}
+
+// MARK: Contains ALL of the elements as keys.
+public func containsAllKeysOf<K, V>(values elements: K...) -> ParameterMatcher<[K: V]> {
+    return containsAllKeysOf(elements)
+}
+public func containsAllKeysOf<S: Sequence, V>(_ elements: S) -> ParameterMatcher<[S.Element: V]> {
+    return ParameterMatcher { dictionary in
+        containsAllOf(elements).matches(dictionary.keys)
+    }
+}
+
+// MARK: Contains NONE of the elements as keys.
+public func containsNoKeysOf<K, V>(values elements: K...) -> ParameterMatcher<[K: V]> {
+    return containsNoKeysOf(elements)
+}
+public func containsNoKeysOf<S: Sequence, V>(_ elements: S) -> ParameterMatcher<[S.Element: V]> {
+    return not(containsAnyKeysOf(elements))
+}
+
+
+// MARK: VALUES MATCHING
+// MARK: Contains ANY of the elements as values.
+public func containsAnyValuesOf<K, V>(values elements: V..., where equality: @escaping (V, V) -> Bool) -> ParameterMatcher<[K: V]> {
+    return containsAnyValuesOf(elements, where: equality)
+}
+public func containsAnyValuesOf<K, S: Sequence>(_ elements: S, where equality: @escaping (S.Element, S.Element) -> Bool) -> ParameterMatcher<[K: S.Element]> {
+    return ParameterMatcher { dictionary in
+        containsAnyOf(elements, where: equality).matches(dictionary.values)
+    }
+}
+
+public func containsAnyValuesOf<K, V: Equatable>(values elements: V...) -> ParameterMatcher<[K: V]> {
+    return containsAnyValuesOf(elements)
+}
+public func containsAnyValuesOf<K, S: Sequence>(_ elements: S) -> ParameterMatcher<[K: S.Element]> where S.Element: Equatable {
+    return containsAnyValuesOf(elements, where: ==)
+}
+
+public func containsAnyValuesOf<K, V: Hashable>(values elements: V...) -> ParameterMatcher<[K: V]> {
+    return containsAnyValuesOf(elements)
+}
+public func containsAnyValuesOf<K, S: Sequence>(_ elements: S) -> ParameterMatcher<[K: S.Element]> where S.Element: Hashable {
+    return ParameterMatcher { dictionary in
+        containsAnyOf(elements).matches(dictionary.values)
+    }
+}
+
+// MARK: Contains ALL of the elements as values.
+public func containsAllValuesOf<K, V>(values elements: V..., where equality: @escaping (V, V) -> Bool) -> ParameterMatcher<[K: V]> {
+    return containsAllValuesOf(elements, where: equality)
+}
+public func containsAllValuesOf<K, S: Sequence>(_ elements: S, where equality: @escaping (S.Element, S.Element) -> Bool) -> ParameterMatcher<[K: S.Element]> {
+    return ParameterMatcher { dictionary in
+        containsAllOf(elements, where: equality).matches(dictionary.values)
+    }
+}
+
+public func containsAllValuesOf<K, V: Equatable>(values elements: V...) -> ParameterMatcher<[K: V]> {
+    return containsAllValuesOf(elements)
+}
+public func containsAllValuesOf<K, S: Sequence>(_ elements: S) -> ParameterMatcher<[K: S.Element]> where S.Element: Equatable {
+    return containsAllValuesOf(elements, where: ==)
+}
+
+public func containsAllValuesOf<K, V: Hashable>(values elements: V...) -> ParameterMatcher<[K: V]> {
+    return containsAllValuesOf(elements)
+}
+public func containsAllValuesOf<K, S: Sequence>(_ elements: S) -> ParameterMatcher<[K: S.Element]> where S.Element: Hashable {
+    return ParameterMatcher { dictionary in
+        containsAllOf(elements).matches(dictionary.values)
+    }
+}
+
+// MARK: Contains NONE of the elements as values.
+public func containsNoValuesOf<K, V>(values elements: V..., where equality: @escaping (V, V) -> Bool) -> ParameterMatcher<[K: V]> {
+    return containsNoValuesOf(elements, where: equality)
+}
+public func containsNoValuesOf<K, S: Sequence>(_ elements: S, where equality: @escaping (S.Element, S.Element) -> Bool) -> ParameterMatcher<[K: S.Element]> {
+    return not(containsAnyValuesOf(elements, where: equality))
+}
+
+public func containsNoValuesOf<K, V: Equatable>(values elements: V...) -> ParameterMatcher<[K: V]> {
+    return containsNoValuesOf(elements)
+}
+public func containsNoValuesOf<K, S: Sequence>(_ elements: S) -> ParameterMatcher<[K: S.Element]> where S.Element: Equatable {
+    return containsNoValuesOf(elements, where: ==)
+}
+
+public func containsNoValuesOf<K, V: Hashable>(values elements: V...) -> ParameterMatcher<[K: V]> {
+    return containsNoValuesOf(elements)
+}
+public func containsNoValuesOf<K, S: Sequence>(_ elements: S) -> ParameterMatcher<[K: S.Element]> where S.Element: Hashable {
+    return not(containsAnyValuesOf(elements))
+}

--- a/Source/Matching/Dictionary+matchers.swift
+++ b/Source/Matching/Dictionary+matchers.swift
@@ -22,9 +22,20 @@ extension Dictionary: Matchable where Value: Matchable, Value == Value.MatchedTy
 
 // MARK: PAIR MATCHING
 // MARK: Contains ANY of the elements as key-value pairs.
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains any of the key-value pairs from the passed dictionary.
+ * - parameter inputDictionary: Dictionary that is used for matching.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAnyOf<K, V: Equatable>(_ inputDictionary: [K: V]) -> ParameterMatcher<[K: V]> {
     return containsAnyOf(inputDictionary, where: ==)
 }
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains any of the key-value pairs from the passed dictionary.
+ * - parameter inputDictionary: Dictionary that is used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAnyOf<K, V>(_ inputDictionary: [K: V], where equality: @escaping (V, V) -> Bool) -> ParameterMatcher<[K: V]> {
     return ParameterMatcher { dictionary in
         inputDictionary.contains { key, value in
@@ -34,9 +45,20 @@ public func containsAnyOf<K, V>(_ inputDictionary: [K: V], where equality: @esca
 }
 
 // MARK: Contains ALL of the elements as key-value pairs.
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains all of the key-value pairs from the passed dictionary.
+ * - parameter inputDictionary: Dictionary that is used for matching.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAllOf<K, V: Equatable>(_ inputDictionary: [K: V]) -> ParameterMatcher<[K: V]> {
     return containsAllOf(inputDictionary, where: ==)
 }
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains all of the key-value pairs from the passed dictionary.
+ * - parameter inputDictionary: Dictionary that is used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAllOf<K, V>(_ inputDictionary: [K: V], where equality: @escaping (V, V) -> Bool) -> ParameterMatcher<[K: V]> {
     return ParameterMatcher { dictionary in
         inputDictionary.allSatisfy { key, value in
@@ -46,9 +68,20 @@ public func containsAllOf<K, V>(_ inputDictionary: [K: V], where equality: @esca
 }
 
 // MARK: Contains NONE of the elements as key-value pairs.
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains none of the key-value pairs from the passed dictionary.
+ * - parameter inputDictionary: Dictionary that is used for matching.
+ * - returns: ParameterMatcher object.
+ */
 public func containsNoneOf<K, V: Equatable>(_ inputDictionary: [K: V]) -> ParameterMatcher<[K: V]> {
     return containsNoneOf(inputDictionary, where: ==)
 }
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains none of the key-value pairs from the passed dictionary.
+ * - parameter inputDictionary: Dictionary that is used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsNoneOf<K, V>(_ inputDictionary: [K: V], where equality: @escaping (V, V) -> Bool) -> ParameterMatcher<[K: V]> {
     return not(containsAnyOf(inputDictionary, where: equality))
 }
@@ -56,9 +89,19 @@ public func containsNoneOf<K, V>(_ inputDictionary: [K: V], where equality: @esc
 
 // MARK: KEYS MATCHING
 // MARK: Contains ANY of the elements as keys.
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains any of the passed keys.
+ * - parameter values: Variadic keys that are used for matching.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAnyKeysOf<K, V>(values elements: K...) -> ParameterMatcher<[K: V]> {
     return containsAnyKeysOf(elements)
 }
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains any of the passed keys.
+ * - parameter elements: Keys that are used for matching.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAnyKeysOf<S: Sequence, V>(_ elements: S) -> ParameterMatcher<[S.Element: V]> {
     return ParameterMatcher { dictionary in
         containsAnyOf(elements).matches(dictionary.keys)
@@ -66,9 +109,19 @@ public func containsAnyKeysOf<S: Sequence, V>(_ elements: S) -> ParameterMatcher
 }
 
 // MARK: Contains ALL of the elements as keys.
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains all of the passed keys.
+ * - parameter values: Variadic keys that are used for matching
+ * - returns: ParameterMatcher object.
+ */
 public func containsAllKeysOf<K, V>(values elements: K...) -> ParameterMatcher<[K: V]> {
     return containsAllKeysOf(elements)
 }
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains all of the passed keys.
+ * - parameter elements: Keys that are used for matching.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAllKeysOf<S: Sequence, V>(_ elements: S) -> ParameterMatcher<[S.Element: V]> {
     return ParameterMatcher { dictionary in
         containsAllOf(elements).matches(dictionary.keys)
@@ -76,9 +129,19 @@ public func containsAllKeysOf<S: Sequence, V>(_ elements: S) -> ParameterMatcher
 }
 
 // MARK: Contains NONE of the elements as keys.
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains none of the passed keys.
+ * - parameter values: Variadic keys that are used for matching
+ * - returns: ParameterMatcher object.
+ */
 public func containsNoKeysOf<K, V>(values elements: K...) -> ParameterMatcher<[K: V]> {
     return containsNoKeysOf(elements)
 }
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains none of the passed keys.
+ * - parameter elements: Keys that are used for matching.
+ * - returns: ParameterMatcher object.
+ */
 public func containsNoKeysOf<S: Sequence, V>(_ elements: S) -> ParameterMatcher<[S.Element: V]> {
     return not(containsAnyKeysOf(elements))
 }
@@ -86,25 +149,58 @@ public func containsNoKeysOf<S: Sequence, V>(_ elements: S) -> ParameterMatcher<
 
 // MARK: VALUES MATCHING
 // MARK: Contains ANY of the elements as values.
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains any of the passed values.
+ * - parameter values: Variadic values that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAnyValuesOf<K, V>(values elements: V..., where equality: @escaping (V, V) -> Bool) -> ParameterMatcher<[K: V]> {
     return containsAnyValuesOf(elements, where: equality)
 }
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains any of the passed values.
+ * - parameter elements: Values that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAnyValuesOf<K, S: Sequence>(_ elements: S, where equality: @escaping (S.Element, S.Element) -> Bool) -> ParameterMatcher<[K: S.Element]> {
     return ParameterMatcher { dictionary in
         containsAnyOf(elements, where: equality).matches(dictionary.values)
     }
 }
 
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains any of the passed values.
+ * - parameter values: Variadic keys that are used for matching
+ * - returns: ParameterMatcher object.
+ */
 public func containsAnyValuesOf<K, V: Equatable>(values elements: V...) -> ParameterMatcher<[K: V]> {
     return containsAnyValuesOf(elements)
 }
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains any of the passed values.
+ * - parameter elements: Keys that are used for matching.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAnyValuesOf<K, S: Sequence>(_ elements: S) -> ParameterMatcher<[K: S.Element]> where S.Element: Equatable {
     return containsAnyValuesOf(elements, where: ==)
 }
 
+
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains any of the passed values.
+ * - parameter values: Variadic values that are used for matching
+ * - returns: ParameterMatcher object.
+ */
 public func containsAnyValuesOf<K, V: Hashable>(values elements: V...) -> ParameterMatcher<[K: V]> {
     return containsAnyValuesOf(elements)
 }
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains none of the passed values.
+ * - parameter elements: Values that are used for matching.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAnyValuesOf<K, S: Sequence>(_ elements: S) -> ParameterMatcher<[K: S.Element]> where S.Element: Hashable {
     return ParameterMatcher { dictionary in
         containsAnyOf(elements).matches(dictionary.values)
@@ -112,25 +208,57 @@ public func containsAnyValuesOf<K, S: Sequence>(_ elements: S) -> ParameterMatch
 }
 
 // MARK: Contains ALL of the elements as values.
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains all of the passed values.
+ * - parameter values: Variadic values that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAllValuesOf<K, V>(values elements: V..., where equality: @escaping (V, V) -> Bool) -> ParameterMatcher<[K: V]> {
     return containsAllValuesOf(elements, where: equality)
 }
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains all of the passed values.
+ * - parameter elements: Values that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAllValuesOf<K, S: Sequence>(_ elements: S, where equality: @escaping (S.Element, S.Element) -> Bool) -> ParameterMatcher<[K: S.Element]> {
     return ParameterMatcher { dictionary in
         containsAllOf(elements, where: equality).matches(dictionary.values)
     }
 }
 
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains all of the passed values.
+ * - parameter values: Variadic values that are used for matching.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAllValuesOf<K, V: Equatable>(values elements: V...) -> ParameterMatcher<[K: V]> {
     return containsAllValuesOf(elements)
 }
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains all of the passed values.
+ * - parameter elements: Values that are used for matching.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAllValuesOf<K, S: Sequence>(_ elements: S) -> ParameterMatcher<[K: S.Element]> where S.Element: Equatable {
     return containsAllValuesOf(elements, where: ==)
 }
 
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains all of the passed values.
+ * - parameter values: Variadic values that are used for matching.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAllValuesOf<K, V: Hashable>(values elements: V...) -> ParameterMatcher<[K: V]> {
     return containsAllValuesOf(elements)
 }
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains all of the passed values.
+ * - parameter elements: Values that are used for matching.
+ * - returns: ParameterMatcher object.
+ */
 public func containsAllValuesOf<K, S: Sequence>(_ elements: S) -> ParameterMatcher<[K: S.Element]> where S.Element: Hashable {
     return ParameterMatcher { dictionary in
         containsAllOf(elements).matches(dictionary.values)
@@ -138,23 +266,59 @@ public func containsAllValuesOf<K, S: Sequence>(_ elements: S) -> ParameterMatch
 }
 
 // MARK: Contains NONE of the elements as values.
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains none of the passed values.
+ * - parameter values: Variadic values that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsNoValuesOf<K, V>(values elements: V..., where equality: @escaping (V, V) -> Bool) -> ParameterMatcher<[K: V]> {
     return containsNoValuesOf(elements, where: equality)
 }
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains none of the passed values.
+ * - parameter elements: Values that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsNoValuesOf<K, S: Sequence>(_ elements: S, where equality: @escaping (S.Element, S.Element) -> Bool) -> ParameterMatcher<[K: S.Element]> {
     return not(containsAnyValuesOf(elements, where: equality))
 }
 
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains none of the passed values.
+ * - parameter values: Variadic values that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsNoValuesOf<K, V: Equatable>(values elements: V...) -> ParameterMatcher<[K: V]> {
     return containsNoValuesOf(elements)
 }
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains none of the passed values.
+ * - parameter elements: Values that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsNoValuesOf<K, S: Sequence>(_ elements: S) -> ParameterMatcher<[K: S.Element]> where S.Element: Equatable {
     return containsNoValuesOf(elements, where: ==)
 }
 
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains none of the passed values.
+ * - parameter values: Variadic values that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsNoValuesOf<K, V: Hashable>(values elements: V...) -> ParameterMatcher<[K: V]> {
     return containsNoValuesOf(elements)
 }
+/**
+ * Matcher for dictionaries that checks if the matching dictionary contains none of the passed values.
+ * - parameter elements: Values that are used for matching.
+ * - parameter where: Closure for determining equality of elements that don't conform to `Equatable`.
+ * - returns: ParameterMatcher object.
+ */
 public func containsNoValuesOf<K, S: Sequence>(_ elements: S) -> ParameterMatcher<[K: S.Element]> where S.Element: Hashable {
     return not(containsAnyValuesOf(elements))
 }

--- a/Source/Matching/ParameterMatcherFunctions.swift
+++ b/Source/Matching/ParameterMatcherFunctions.swift
@@ -171,17 +171,6 @@ public func anyOptionalThrowingClosure<IN, OUT>() -> ParameterMatcher<(((IN)) th
     return notNil()
 }
 
-/// Returns a matcher matching any non nil value.
-public func notNil<T>() -> ParameterMatcher<T?> {
-    return ParameterMatcher {
-        if case .none = $0 {
-            return false
-        } else {
-            return true
-        }
-    }
-}
-
 /// Returns a matcher matching any nil value
 public func isNil<T>() -> ParameterMatcher<T?> {
     return ParameterMatcher {
@@ -190,5 +179,17 @@ public func isNil<T>() -> ParameterMatcher<T?> {
         } else {
             return false
         }
+    }
+}
+
+/// Returns a matcher matching any non nil value.
+public func notNil<T>() -> ParameterMatcher<T?> {
+    return not(isNil())
+}
+
+/// Returns a matcher negating any matcher it's applied to.
+public func not<T>(_ matcher: ParameterMatcher<T>) -> ParameterMatcher<T> {
+    return ParameterMatcher { value in
+        !matcher.matches(value)
     }
 }

--- a/Source/Matching/Set+matchers.swift
+++ b/Source/Matching/Set+matchers.swift
@@ -1,0 +1,16 @@
+//
+//  Set+matchers.swift
+//  Cuckoo
+//
+//  Created by Matyáš Kříž on 04/09/2019.
+//
+
+extension Set: Matchable where Element: Matchable, Element == Element.MatchedType {
+    public typealias MatchedType = Set<Element>
+
+    public var matcher: ParameterMatcher<Set<Element>> {
+        return ParameterMatcher<Set<Element>> { other in
+            return self == other
+        }
+    }
+}

--- a/Tests/ClassTest.swift
+++ b/Tests/ClassTest.swift
@@ -509,5 +509,13 @@ class ClassTest: XCTestCase {
 
         XCTAssertFalse(mock.a(a: Set([true, true, false])))
         XCTAssertFalse(mock.a(a: Set([false, true, true])))
+
+        verify(mock).a(a: [1])
+        verify(mock).a(a: ["gg"])
+        verify(mock).a(a: [false])
+
+        verify(mock, times(3)).a(a: any(Dictionary<Int, Bool>.self))
+
+        verify(mock, times(2)).a(a: any(Set<Bool>.self))
     }
 }

--- a/Tests/ClassTest.swift
+++ b/Tests/ClassTest.swift
@@ -485,4 +485,28 @@ class ClassTest: XCTestCase {
         XCTAssertEqual(String(describing: type(of: mock.boolMaybeYes)), String(describing: type(of: original.boolMaybeYes)))
         XCTAssertEqual(String(describing: type(of: mock.largeInty)), String(describing: type(of: original.largeInty)))
     }
+
+    func testConvenienceMatcherAmbiguity() {
+        let mock = MockConvenienceMatchersAmbiguer()
+        stub(mock) { stub in
+            when(stub.a(a: [1])).thenReturn(false)
+            when(stub.a(a: ["gg"])).thenReturn(false)
+            when(stub.a(a: [false])).thenReturn(false)
+            when(stub.a(a: "gg")).thenReturn(false)
+
+            when(stub.a(a: [1: true])).then { $0[1] ?? false }
+            when(stub.a(a: [1: true, 2: false])).then { _ in true }
+            when(stub.a(a: Set([true, true, false]))).thenReturn(false)
+        }
+
+        XCTAssertFalse(mock.a(a: [1]))
+        XCTAssertFalse(mock.a(a: ["gg"]))
+        XCTAssertFalse(mock.a(a: [false]))
+
+        XCTAssertTrue(mock.a(a: [1: true]))
+        XCTAssertTrue(mock.a(a: [1: true, 2: false]))
+
+        XCTAssertFalse(mock.a(a: Set([true, true, false])))
+        XCTAssertFalse(mock.a(a: Set([false, true, true])))
+    }
 }

--- a/Tests/ClassTest.swift
+++ b/Tests/ClassTest.swift
@@ -505,6 +505,7 @@ class ClassTest: XCTestCase {
 
         XCTAssertTrue(mock.a(a: [1: true]))
         XCTAssertTrue(mock.a(a: [1: true, 2: false]))
+        XCTAssertTrue(mock.a(a: [2: false, 1: true]))
 
         XCTAssertFalse(mock.a(a: Set([true, true, false])))
         XCTAssertFalse(mock.a(a: Set([false, true, true])))

--- a/Tests/Matching/Array+matchersTest.swift
+++ b/Tests/Matching/Array+matchersTest.swift
@@ -108,6 +108,18 @@ class ArrayMatcherTest: XCTestCase {
         XCTAssertFalse(containsAllOf((1...3).map(TestStructs.H.init)).matches([3].map(TestStructs.H.init)))
     }
 
+    func testContainsAllOfMultiple() {
+        XCTAssertFalse(containsAllOf(values: 1, 3, 2, 2, 1).matches([2]))
+        XCTAssertFalse(containsAllOf(values: 1, 3, 2, 2, 1).matches([1, 2, 3]))
+        XCTAssertFalse(containsAllOf(values: 1, 3, 2, 2, 1).matches([1, 3, 2, 2]))
+        XCTAssertTrue(containsAllOf(values: 1, 3, 2, 2, 1).matches([1, 3, 2, 2, 1]))
+
+        XCTAssertFalse(containsAllOf([1, 3, 2, 2, 1]).matches([2]))
+        XCTAssertFalse(containsAllOf([1, 3, 2, 2, 1]).matches([1, 2, 3]))
+        XCTAssertFalse(containsAllOf([1, 3, 2, 2, 1]).matches([1, 3, 2, 2]))
+        XCTAssertTrue(containsAllOf([1, 3, 2, 2, 1]).matches([1, 3, 2, 2, 1]))
+    }
+
     // MARK: Contains NONE of the elements.
     func testContainsNoneOf() {
         // Variadic parameters.

--- a/Tests/Matching/Array+matchersTest.swift
+++ b/Tests/Matching/Array+matchersTest.swift
@@ -1,0 +1,182 @@
+//
+//  Array+matchersTest.swift
+//  Cuckoo
+//
+//  Created by Matyáš Kříž on 05/09/2019.
+//
+
+import XCTest
+
+struct TestStructs {
+    struct N {
+        let g: Int
+    }
+    struct E: Equatable {
+        let g: Int
+    }
+    struct H: Hashable {
+        let g: Int
+    }
+}
+
+class ArrayMatcherTest: XCTestCase {
+    // MARK: Contains ANY of the elements.
+    func testContainsAnyOf() {
+        // Variadic parameters.
+        XCTAssertFalse(containsAnyOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([2].map(TestStructs.N.init)))
+        XCTAssertTrue(containsAnyOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([1, 2, 3].map(TestStructs.N.init)))
+        XCTAssertTrue(containsAnyOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([1, 2, 3, 4, 5].map(TestStructs.N.init)))
+        XCTAssertFalse(containsAnyOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([4, 5, 6, 0].map(TestStructs.N.init)))
+        XCTAssertFalse(containsAnyOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([].map(TestStructs.N.init)))
+
+        // Passed by array.
+        XCTAssertTrue(containsAnyOf((1...3).map(TestStructs.N.init), where: { $0.g == $1.g }).matches([2].map(TestStructs.N.init)))
+        XCTAssertTrue(containsAnyOf((1...3).map(TestStructs.N.init), where: { $0.g == $1.g }).matches([1, 2, 3].map(TestStructs.N.init)))
+        XCTAssertTrue(containsAnyOf((1...3).map(TestStructs.N.init), where: { $0.g == $1.g }).matches([1, 2, 3, 4, 5].map(TestStructs.N.init)))
+        XCTAssertFalse(containsAnyOf((1...3).map(TestStructs.N.init), where: { $0.g == $1.g }).matches([4, 5, 6, 0].map(TestStructs.N.init)))
+        XCTAssertFalse(containsAnyOf((1...3).map(TestStructs.N.init), where: { $0.g == $1.g }).matches([].map(TestStructs.N.init)))
+    }
+
+    func testContainsAnyOfEquatable() {
+        XCTAssertFalse(containsAnyOf(values: .init(g: 1), .init(g: 3)).matches([2].map(TestStructs.E.init)))
+        XCTAssertTrue(containsAnyOf(values: .init(g: 1), .init(g: 3)).matches([1, 2, 3].map(TestStructs.E.init)))
+        XCTAssertTrue(containsAnyOf(values: .init(g: 1), .init(g: 3)).matches([1, 2, 3, 4, 5].map(TestStructs.E.init)))
+        XCTAssertFalse(containsAnyOf(values: .init(g: 1), .init(g: 3)).matches([4, 5, 6, 0].map(TestStructs.E.init)))
+        XCTAssertFalse(containsAnyOf(values: .init(g: 1), .init(g: 3)).matches([].map(TestStructs.E.init)))
+
+        XCTAssertTrue(containsAnyOf((1...3).map(TestStructs.E.init)).matches([2].map(TestStructs.E.init)))
+        XCTAssertTrue(containsAnyOf((1...3).map(TestStructs.E.init)).matches([1, 2, 3].map(TestStructs.E.init)))
+        XCTAssertTrue(containsAnyOf((1...3).map(TestStructs.E.init)).matches([1, 2, 3, 4, 5].map(TestStructs.E.init)))
+        XCTAssertFalse(containsAnyOf((1...3).map(TestStructs.E.init)).matches([4, 5, 6, 0].map(TestStructs.E.init)))
+        XCTAssertFalse(containsAnyOf((1...3).map(TestStructs.E.init)).matches([].map(TestStructs.E.init)))
+    }
+
+    func testContainsAnyOfHashable() {
+        XCTAssertFalse(containsAnyOf(values: .init(g: 1), .init(g: 3)).matches([2].map(TestStructs.H.init)))
+        XCTAssertTrue(containsAnyOf(values: .init(g: 1), .init(g: 3)).matches([1, 2, 3].map(TestStructs.H.init)))
+        XCTAssertTrue(containsAnyOf(values: .init(g: 1), .init(g: 3)).matches([1, 2, 3, 4, 5].map(TestStructs.H.init)))
+        XCTAssertFalse(containsAnyOf(values: .init(g: 1), .init(g: 3)).matches([4, 5, 6, 0].map(TestStructs.H.init)))
+        XCTAssertFalse(containsAnyOf(values: .init(g: 1), .init(g: 3)).matches([].map(TestStructs.H.init)))
+
+        XCTAssertTrue(containsAnyOf((1...3).map(TestStructs.H.init)).matches([2].map(TestStructs.H.init)))
+        XCTAssertTrue(containsAnyOf((1...3).map(TestStructs.H.init)).matches([1, 2, 3].map(TestStructs.H.init)))
+        XCTAssertTrue(containsAnyOf((1...3).map(TestStructs.H.init)).matches([1, 2, 3, 4, 5].map(TestStructs.H.init)))
+        XCTAssertFalse(containsAnyOf((1...3).map(TestStructs.H.init)).matches([4, 5, 6, 0].map(TestStructs.H.init)))
+        XCTAssertFalse(containsAnyOf((1...3).map(TestStructs.H.init)).matches([].map(TestStructs.H.init)))
+    }
+
+    // MARK: Contains ALL of the elements.
+    func testContainsAllOf() {
+        XCTAssertFalse(containsAllOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([2].map(TestStructs.N.init)))
+        XCTAssertTrue(containsAllOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([1, 2, 3].map(TestStructs.N.init)))
+        XCTAssertTrue(containsAllOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([1, 2, 3, 4, 5].map(TestStructs.N.init)))
+        XCTAssertFalse(containsAllOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([4, 5, 6, 0].map(TestStructs.N.init)))
+        XCTAssertFalse(containsAllOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([3].map(TestStructs.N.init)))
+
+        XCTAssertFalse(containsAllOf((1...3).map(TestStructs.N.init), where: { $0.g == $1.g }).matches([2].map(TestStructs.N.init)))
+        XCTAssertTrue(containsAllOf((1...3).map(TestStructs.N.init), where: { $0.g == $1.g }).matches([1, 2, 3].map(TestStructs.N.init)))
+        XCTAssertTrue(containsAllOf((1...3).map(TestStructs.N.init), where: { $0.g == $1.g }).matches([1, 2, 3, 4, 5].map(TestStructs.N.init)))
+        XCTAssertFalse(containsAllOf((1...3).map(TestStructs.N.init), where: { $0.g == $1.g }).matches([4, 5, 6, 0].map(TestStructs.N.init)))
+        XCTAssertFalse(containsAllOf((1...3).map(TestStructs.N.init), where: { $0.g == $1.g }).matches([3].map(TestStructs.N.init)))
+    }
+
+    func testContainsAllOfEquatable() {
+        XCTAssertFalse(containsAllOf(values: .init(g: 1), .init(g: 3)).matches([2].map(TestStructs.E.init)))
+        XCTAssertTrue(containsAllOf(values: .init(g: 1), .init(g: 3)).matches([1, 2, 3].map(TestStructs.E.init)))
+        XCTAssertTrue(containsAllOf(values: .init(g: 1), .init(g: 3)).matches([1, 2, 3, 4, 5].map(TestStructs.E.init)))
+        XCTAssertFalse(containsAllOf(values: .init(g: 1), .init(g: 3)).matches([4, 5, 6, 0].map(TestStructs.E.init)))
+        XCTAssertFalse(containsAllOf(values: .init(g: 1), .init(g: 3)).matches([3].map(TestStructs.E.init)))
+
+        XCTAssertFalse(containsAllOf((1...3).map(TestStructs.E.init)).matches([2].map(TestStructs.E.init)))
+        XCTAssertTrue(containsAllOf((1...3).map(TestStructs.E.init)).matches([1, 2, 3].map(TestStructs.E.init)))
+        XCTAssertTrue(containsAllOf((1...3).map(TestStructs.E.init)).matches([1, 2, 3, 4, 5].map(TestStructs.E.init)))
+        XCTAssertFalse(containsAllOf((1...3).map(TestStructs.E.init)).matches([4, 5, 6, 0].map(TestStructs.E.init)))
+        XCTAssertFalse(containsAllOf((1...3).map(TestStructs.E.init)).matches([3].map(TestStructs.E.init)))
+    }
+
+    func testContainsAllOfHashable() {
+        XCTAssertFalse(containsAllOf(values: .init(g: 1), .init(g: 3)).matches([2].map(TestStructs.H.init)))
+        XCTAssertTrue(containsAllOf(values: .init(g: 1), .init(g: 3)).matches([1, 2, 3].map(TestStructs.H.init)))
+        XCTAssertTrue(containsAllOf(values: .init(g: 1), .init(g: 3)).matches([1, 2, 3, 4, 5].map(TestStructs.H.init)))
+        XCTAssertFalse(containsAllOf(values: .init(g: 1), .init(g: 3)).matches([4, 5, 6, 0].map(TestStructs.H.init)))
+        XCTAssertFalse(containsAllOf(values: .init(g: 1), .init(g: 3)).matches([3].map(TestStructs.H.init)))
+
+        XCTAssertFalse(containsAllOf((1...3).map(TestStructs.H.init)).matches([2].map(TestStructs.H.init)))
+        XCTAssertTrue(containsAllOf((1...3).map(TestStructs.H.init)).matches([1, 2, 3].map(TestStructs.H.init)))
+        XCTAssertTrue(containsAllOf((1...3).map(TestStructs.H.init)).matches([1, 2, 3, 4, 5].map(TestStructs.H.init)))
+        XCTAssertFalse(containsAllOf((1...3).map(TestStructs.H.init)).matches([4, 5, 6, 0].map(TestStructs.H.init)))
+        XCTAssertFalse(containsAllOf((1...3).map(TestStructs.H.init)).matches([3].map(TestStructs.H.init)))
+    }
+
+    // MARK: Contains NONE of the elements.
+    func testContainsNoneOf() {
+        // Variadic parameters.
+        XCTAssertTrue(containsNoneOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([2].map(TestStructs.N.init)))
+        XCTAssertFalse(containsNoneOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([1, 2, 3].map(TestStructs.N.init)))
+        XCTAssertFalse(containsNoneOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([1, 2, 3, 4, 5].map(TestStructs.N.init)))
+        XCTAssertTrue(containsNoneOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([4, 5, 6, 0].map(TestStructs.N.init)))
+        XCTAssertTrue(containsNoneOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([].map(TestStructs.N.init)))
+
+        // Passed by array.
+        XCTAssertFalse(containsNoneOf((1...3).map(TestStructs.N.init), where: { $0.g == $1.g }).matches([2].map(TestStructs.N.init)))
+        XCTAssertFalse(containsNoneOf((1...3).map(TestStructs.N.init), where: { $0.g == $1.g }).matches([1, 2, 3].map(TestStructs.N.init)))
+        XCTAssertFalse(containsNoneOf((1...3).map(TestStructs.N.init), where: { $0.g == $1.g }).matches([1, 2, 3, 4, 5].map(TestStructs.N.init)))
+        XCTAssertTrue(containsNoneOf((1...3).map(TestStructs.N.init), where: { $0.g == $1.g }).matches([4, 5, 6, 0].map(TestStructs.N.init)))
+        XCTAssertTrue(containsNoneOf((1...3).map(TestStructs.N.init), where: { $0.g == $1.g }).matches([].map(TestStructs.N.init)))
+    }
+
+    func testContainsNoneOfEquatable() {
+        XCTAssertTrue(containsNoneOf(values: .init(g: 1), .init(g: 3)).matches([2].map(TestStructs.E.init)))
+        XCTAssertFalse(containsNoneOf(values: .init(g: 1), .init(g: 3)).matches([1, 2, 3].map(TestStructs.E.init)))
+        XCTAssertFalse(containsNoneOf(values: .init(g: 1), .init(g: 3)).matches([1, 2, 3, 4, 5].map(TestStructs.E.init)))
+        XCTAssertTrue(containsNoneOf(values: .init(g: 1), .init(g: 3)).matches([4, 5, 6, 0].map(TestStructs.E.init)))
+        XCTAssertTrue(containsNoneOf(values: .init(g: 1), .init(g: 3)).matches([].map(TestStructs.E.init)))
+
+        XCTAssertFalse(containsNoneOf((1...3).map(TestStructs.E.init)).matches([2].map(TestStructs.E.init)))
+        XCTAssertFalse(containsNoneOf((1...3).map(TestStructs.E.init)).matches([1, 2, 3].map(TestStructs.E.init)))
+        XCTAssertFalse(containsNoneOf((1...3).map(TestStructs.E.init)).matches([1, 2, 3, 4, 5].map(TestStructs.E.init)))
+        XCTAssertTrue(containsNoneOf((1...3).map(TestStructs.E.init)).matches([4, 5, 6, 0].map(TestStructs.E.init)))
+        XCTAssertTrue(containsNoneOf((1...3).map(TestStructs.E.init)).matches([].map(TestStructs.E.init)))
+    }
+
+    func testContainsNoneOfHashable() {
+        XCTAssertTrue(containsNoneOf(values: .init(g: 1), .init(g: 3)).matches([2].map(TestStructs.H.init)))
+        XCTAssertFalse(containsNoneOf(values: .init(g: 1), .init(g: 3)).matches([1, 2, 3].map(TestStructs.H.init)))
+        XCTAssertFalse(containsNoneOf(values: .init(g: 1), .init(g: 3)).matches([1, 2, 3, 4, 5].map(TestStructs.H.init)))
+        XCTAssertTrue(containsNoneOf(values: .init(g: 1), .init(g: 3)).matches([4, 5, 6, 0].map(TestStructs.H.init)))
+        XCTAssertTrue(containsNoneOf(values: .init(g: 1), .init(g: 3)).matches([].map(TestStructs.H.init)))
+
+        XCTAssertFalse(containsNoneOf((1...3).map(TestStructs.H.init)).matches([2].map(TestStructs.H.init)))
+        XCTAssertFalse(containsNoneOf((1...3).map(TestStructs.H.init)).matches([1, 2, 3].map(TestStructs.H.init)))
+        XCTAssertFalse(containsNoneOf((1...3).map(TestStructs.H.init)).matches([1, 2, 3, 4, 5].map(TestStructs.H.init)))
+        XCTAssertTrue(containsNoneOf((1...3).map(TestStructs.H.init)).matches([4, 5, 6, 0].map(TestStructs.H.init)))
+        XCTAssertTrue(containsNoneOf((1...3).map(TestStructs.H.init)).matches([].map(TestStructs.H.init)))
+    }
+
+    // MARK: Has length N (exact, at least, at most).
+    func testHasLengthExact() {
+        XCTAssertTrue(hasLength(exactly: 4).matches([1, 2, 3, 4]))
+        XCTAssertFalse(hasLength(exactly: 2).matches([1, 2, 3, 4]))
+        XCTAssertTrue(hasLength(exactly: 0).matches([]))
+    }
+
+    func testHasLengthAtLeast() {
+        XCTAssertTrue(hasLength(atLeast: 4).matches([1, 2, 3, 4]))
+        XCTAssertTrue(hasLength(atLeast: 2).matches([1, 2, 3, 4]))
+        XCTAssertTrue(hasLength(atLeast: 0).matches([]))
+
+        XCTAssertFalse(hasLength(atLeast: 4, inclusive: false).matches([1, 2, 3, 4]))
+        XCTAssertTrue(hasLength(atLeast: 2, inclusive: false).matches([1, 2, 3, 4]))
+        XCTAssertFalse(hasLength(atLeast: 0, inclusive: false).matches([]))
+    }
+
+    func testHasLengthAtMost() {
+        XCTAssertTrue(hasLength(atMost: 4).matches([1, 2, 3, 4]))
+        XCTAssertFalse(hasLength(atMost: 2).matches([1, 2, 3, 4]))
+        XCTAssertTrue(hasLength(atMost: 0).matches([]))
+
+        XCTAssertTrue(hasLength(atMost: 5, inclusive: false).matches([1, 2, 3, 4]))
+        XCTAssertFalse(hasLength(atMost: 2, inclusive: false).matches([1, 2, 3, 4]))
+        XCTAssertFalse(hasLength(atMost: 0, inclusive: false).matches([]))
+    }
+}

--- a/Tests/Matching/Dictionary+matchersTest.swift
+++ b/Tests/Matching/Dictionary+matchersTest.swift
@@ -1,0 +1,254 @@
+//
+//  Dictionary+matchersTest.swift
+//  Cuckoo
+//
+//  Created by Matyáš Kříž on 05/09/2019.
+//
+
+import XCTest
+
+class DictionaryParameterMatcherTest: XCTestCase {
+    // MARK: Contains ANY of the elements as key-value pairs.
+    func testContainsAnyOf() {
+        // With keys identical to values.
+        XCTAssertFalse(containsAnyOf([1, 3].toDictionaryAsKeysWithHashable()).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertTrue(containsAnyOf([1, 3].toDictionaryAsKeysWithEquatable()).matches([1, 2].toDictionaryAsKeysWithEquatable()))
+        XCTAssertFalse(containsAnyOf([1, 3].toDictionaryAsKeysWithNonEquatable(), where: { $0.g == $1.g }).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertTrue(containsAnyOf([1, 3].toDictionaryAsKeysWithEquatable()).matches([1, 3].toDictionaryAsKeysWithEquatable()))
+        XCTAssertTrue(containsAnyOf([1, 3].toDictionaryAsKeysWithHashable()).matches([1, 2, 3].toDictionaryAsKeysWithHashable()))
+
+        // With keys different from values.
+        XCTAssertFalse(containsAnyOf([1, 3].toDictionaryAsKeysWithHashable({ ($0, .init(g: $0 - 1)) })).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertTrue(containsAnyOf([1, 3].toDictionaryAsKeysWithEquatable({ ($0, .init(g: $0 - 1)) })).matches([1, 2].toDictionaryAsKeysWithEquatable({ ($0, .init(g: $0 - 1)) })))
+        XCTAssertFalse(containsAnyOf([1, 3].toDictionaryAsKeysWithNonEquatable({ ($0, .init(g: $0 - 1)) }), where: { $0.g == $1.g }).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertTrue(containsAnyOf([1, 3].toDictionaryAsKeysWithEquatable({ ($0, .init(g: $0 - 1)) })).matches([1, 3].toDictionaryAsKeysWithEquatable({ ($0, .init(g: $0 - 1)) })))
+        XCTAssertTrue(containsAnyOf([1, 3].toDictionaryAsKeysWithHashable({ ($0, .init(g: $0 - 1)) })).matches([1, 2, 3].toDictionaryAsKeysWithHashable({ ($0, .init(g: $0 - 1)) })))
+    }
+
+    // MARK: Contains ALL of the elements as key-value pairs.
+    func testContainsAllOf() {
+        XCTAssertFalse(containsAllOf([1, 3].toDictionaryAsKeysWithHashable()).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertFalse(containsAllOf([1, 3].toDictionaryAsKeysWithEquatable()).matches([1, 2].toDictionaryAsKeysWithEquatable()))
+        XCTAssertFalse(containsAllOf([1, 3].toDictionaryAsKeysWithNonEquatable(), where: { $0.g == $1.g }).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertTrue(containsAllOf([1, 3].toDictionaryAsKeysWithEquatable()).matches([1, 3].toDictionaryAsKeysWithEquatable()))
+        XCTAssertTrue(containsAllOf([1, 3].toDictionaryAsKeysWithHashable()).matches([1, 2, 3].toDictionaryAsKeysWithHashable()))
+
+        XCTAssertFalse(containsAllOf([1, 3].toDictionaryAsKeysWithHashable({ ($0, .init(g: $0 - 1)) })).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertFalse(containsAllOf([1, 3].toDictionaryAsKeysWithEquatable({ ($0, .init(g: $0 - 1)) })).matches([1, 2].toDictionaryAsKeysWithEquatable({ ($0, .init(g: $0 - 1)) })))
+        XCTAssertFalse(containsAllOf([1, 3].toDictionaryAsKeysWithNonEquatable({ ($0, .init(g: $0 - 1)) }), where: { $0.g == $1.g }).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertTrue(containsAllOf([1, 3].toDictionaryAsKeysWithEquatable({ ($0, .init(g: $0 - 1)) })).matches([1, 3].toDictionaryAsKeysWithEquatable({ ($0, .init(g: $0 - 1)) })))
+        XCTAssertTrue(containsAllOf([1, 3].toDictionaryAsKeysWithHashable({ ($0, .init(g: $0 - 1)) })).matches([1, 2, 3].toDictionaryAsKeysWithHashable({ ($0, .init(g: $0 - 1)) })))
+    }
+
+    // MARK: Contains NONE of the elements as key-value pairs.
+    func testContainsNoneOf() {
+        // With keys identical to values.
+        XCTAssertTrue(containsNoneOf([1, 3].toDictionaryAsKeysWithHashable()).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertFalse(containsNoneOf([1, 3].toDictionaryAsKeysWithEquatable()).matches([1, 2].toDictionaryAsKeysWithEquatable()))
+        XCTAssertTrue(containsNoneOf([1, 3].toDictionaryAsKeysWithNonEquatable(), where: { $0.g == $1.g }).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertFalse(containsNoneOf([1, 3].toDictionaryAsKeysWithEquatable()).matches([1, 3].toDictionaryAsKeysWithEquatable()))
+        XCTAssertFalse(containsNoneOf([1, 3].toDictionaryAsKeysWithHashable()).matches([1, 2, 3].toDictionaryAsKeysWithHashable()))
+
+        // With keys different from values.
+        XCTAssertTrue(containsNoneOf([1, 3].toDictionaryAsKeysWithHashable({ ($0, .init(g: $0 - 1)) })).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertFalse(containsNoneOf([1, 3].toDictionaryAsKeysWithEquatable({ ($0, .init(g: $0 - 1)) })).matches([1, 2].toDictionaryAsKeysWithEquatable({ ($0, .init(g: $0 - 1)) })))
+        XCTAssertTrue(containsNoneOf([1, 3].toDictionaryAsKeysWithNonEquatable({ ($0, .init(g: $0 - 1)) }), where: { $0.g == $1.g }).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertFalse(containsNoneOf([1, 3].toDictionaryAsKeysWithEquatable({ ($0, .init(g: $0 - 1)) })).matches([1, 3].toDictionaryAsKeysWithEquatable({ ($0, .init(g: $0 - 1)) })))
+        XCTAssertFalse(containsNoneOf([1, 3].toDictionaryAsKeysWithHashable({ ($0, .init(g: $0 - 1)) })).matches([1, 2, 3].toDictionaryAsKeysWithHashable({ ($0, .init(g: $0 - 1)) })))
+    }
+
+    // MARK: Contains ANY of the elements as keys.
+    func testContainsAnyKeysOf() {
+        // Variadic parameters.
+        XCTAssertFalse(containsAnyKeysOf(values: 1, 3).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertTrue(containsAnyKeysOf(values: 1, 3).matches([1, 2].toDictionaryAsKeysWithEquatable()))
+        XCTAssertFalse(containsAnyKeysOf(values: 1, 3).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertTrue(containsAnyKeysOf(values: 1, 3).matches([1, 3].toDictionaryAsKeysWithEquatable()))
+        XCTAssertTrue(containsAnyKeysOf(values: 1, 3).matches([1, 2, 3].toDictionaryAsKeysWithHashable()))
+
+        // Passed by array.
+        XCTAssertFalse(containsAnyKeysOf([1, 3]).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertTrue(containsAnyKeysOf([1, 3]).matches([1, 2].toDictionaryAsKeysWithEquatable()))
+        XCTAssertFalse(containsAnyKeysOf([1, 3]).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertTrue(containsAnyKeysOf([1, 3]).matches([1, 3].toDictionaryAsKeysWithEquatable()))
+        XCTAssertTrue(containsAnyKeysOf([1, 3]).matches([1, 2, 3].toDictionaryAsKeysWithHashable()))
+    }
+
+    // MARK: Contains ALL of the elements as keys.
+    func testContainsAllKeysOf() {
+        // Variadic parameters.
+        XCTAssertFalse(containsAllKeysOf(values: 1, 3).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertFalse(containsAllKeysOf(values: 1, 3).matches([1, 2].toDictionaryAsKeysWithEquatable()))
+        XCTAssertFalse(containsAllKeysOf(values: 1, 3).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertTrue(containsAllKeysOf(values: 1, 3).matches([1, 3].toDictionaryAsKeysWithEquatable()))
+        XCTAssertTrue(containsAllKeysOf(values: 1, 3).matches([1, 2, 3].toDictionaryAsKeysWithHashable()))
+
+        // Passed by array.
+        XCTAssertFalse(containsAllKeysOf([1, 3]).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertFalse(containsAllKeysOf([1, 3]).matches([1, 2].toDictionaryAsKeysWithEquatable()))
+        XCTAssertFalse(containsAllKeysOf([1, 3]).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertTrue(containsAllKeysOf([1, 3]).matches([1, 3].toDictionaryAsKeysWithEquatable()))
+        XCTAssertTrue(containsAllKeysOf([1, 3]).matches([1, 2, 3].toDictionaryAsKeysWithHashable()))
+    }
+
+    // MARK: Contains NONE of the elements as keys.
+    func testContainsNoKeysOf() {
+        // Variadic parameters.
+        XCTAssertTrue(containsNoKeysOf(values: 1, 3).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertFalse(containsNoKeysOf(values: 1, 3).matches([1, 2].toDictionaryAsKeysWithEquatable()))
+        XCTAssertTrue(containsNoKeysOf(values: 1, 3).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertFalse(containsNoKeysOf(values: 1, 3).matches([1, 3].toDictionaryAsKeysWithEquatable()))
+        XCTAssertFalse(containsNoKeysOf(values: 1, 3).matches([1, 2, 3].toDictionaryAsKeysWithHashable()))
+
+        // Passed by array.
+        XCTAssertTrue(containsNoKeysOf([1, 3]).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertFalse(containsNoKeysOf([1, 3]).matches([1, 2].toDictionaryAsKeysWithEquatable()))
+        XCTAssertTrue(containsNoKeysOf([1, 3]).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertFalse(containsNoKeysOf([1, 3]).matches([1, 3].toDictionaryAsKeysWithEquatable()))
+        XCTAssertFalse(containsNoKeysOf([1, 3]).matches([1, 2, 3].toDictionaryAsKeysWithHashable()))
+    }
+
+    // MARK: Contains ANY of the elements as values.
+    func testContainsAnyValuesOf() {
+        // Variadic parameters.
+        XCTAssertFalse(containsAnyValuesOf(values: .init(g: 1), .init(g: 3)).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertTrue(containsAnyValuesOf(values: .init(g: 1), .init(g: 3)).matches([1, 2].toDictionaryAsKeysWithEquatable()))
+        XCTAssertFalse(containsAnyValuesOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertTrue(containsAnyValuesOf(values: .init(g: 1), .init(g: 3)).matches([1, 3].toDictionaryAsKeysWithEquatable()))
+        XCTAssertTrue(containsAnyValuesOf(values: .init(g: 1), .init(g: 3)).matches([1, 2, 3].toDictionaryAsKeysWithHashable()))
+
+        // Passed by array.
+        XCTAssertFalse(containsAnyValuesOf([1, 3].map(TestStructs.H.init)).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertTrue(containsAnyValuesOf([1, 3].map(TestStructs.E.init)).matches([1, 2].toDictionaryAsKeysWithEquatable()))
+        XCTAssertFalse(containsAnyValuesOf([1, 3].map(TestStructs.N.init), where: { $0.g == $1.g }).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertTrue(containsAnyValuesOf([1, 3].map(TestStructs.E.init)).matches([1, 3].toDictionaryAsKeysWithEquatable()))
+        XCTAssertTrue(containsAnyValuesOf([1, 3].map(TestStructs.H.init)).matches([1, 2, 3].toDictionaryAsKeysWithHashable()))
+
+        XCTAssertTrue(
+            containsAnyValuesOf([.init(g: 1), .init(g: 3)])
+                .matches([2: TestStructs.H(g: 3), 3: .init(g: 1)]))
+        XCTAssertTrue(
+            containsAnyValuesOf([.init(g: 1), .init(g: 3)])
+                .matches([2: TestStructs.H(g: 3), 3: .init(g: 4)]))
+        XCTAssertTrue(
+            containsAnyValuesOf([.init(g: 1), .init(g: 3)])
+                .matches([1: TestStructs.H(g: 3)]))
+        XCTAssertTrue(
+            containsAnyValuesOf([.init(g: 1), .init(g: 3)])
+                .matches([1: TestStructs.H(g: 1)]))
+        XCTAssertFalse(
+            containsAnyValuesOf([.init(g: 1), .init(g: 3)])
+                .matches([2: TestStructs.H(g: -3)]))
+    }
+
+    // MARK: Contains ALL of the elements as values.
+    func testContainsAllValuesOf() {
+        // Variadic parameters.
+        XCTAssertFalse(containsAllValuesOf(values: .init(g: 1), .init(g: 3)).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertFalse(containsAllValuesOf(values: .init(g: 1), .init(g: 3)).matches([1, 2].toDictionaryAsKeysWithEquatable()))
+        XCTAssertFalse(containsAllValuesOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertTrue(containsAllValuesOf(values: .init(g: 1), .init(g: 3)).matches([1, 3].toDictionaryAsKeysWithEquatable()))
+        XCTAssertTrue(containsAllValuesOf(values: .init(g: 1), .init(g: 3)).matches([1, 2, 3].toDictionaryAsKeysWithHashable()))
+
+        // Passed by array.
+        XCTAssertFalse(containsAllValuesOf([1, 3].map(TestStructs.H.init)).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertFalse(containsAllValuesOf([1, 3].map(TestStructs.E.init)).matches([1, 2].toDictionaryAsKeysWithEquatable()))
+        XCTAssertFalse(containsAllValuesOf([1, 3].map(TestStructs.N.init), where: { $0.g == $1.g }).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertTrue(containsAllValuesOf([1, 3].map(TestStructs.E.init)).matches([1, 3].toDictionaryAsKeysWithEquatable()))
+        XCTAssertTrue(containsAllValuesOf([1, 3].map(TestStructs.H.init)).matches([1, 2, 3].toDictionaryAsKeysWithHashable()))
+
+        XCTAssertTrue(
+            containsAllValuesOf([.init(g: 1), .init(g: 3)])
+                .matches([2: TestStructs.H(g: 3), 3: .init(g: 1)]))
+        XCTAssertFalse(
+            containsAllValuesOf([.init(g: 1), .init(g: 3)])
+                .matches([2: TestStructs.H(g: 3), 3: .init(g: 4)]))
+        XCTAssertTrue(
+            containsAllValuesOf([.init(g: 1), .init(g: 3)])
+                .matches([1: TestStructs.H(g: 3), 3: .init(g: 1)]))
+        XCTAssertFalse(
+            containsAllValuesOf([.init(g: 1), .init(g: 3)])
+                .matches([1: TestStructs.H(g: 3), 2: TestStructs.H(g: 3), 3: TestStructs.H(g: 3)]))
+        XCTAssertFalse(
+            containsAllValuesOf([.init(g: 1), .init(g: 3)])
+                .matches([2: TestStructs.H(g: -3)]))
+    }
+
+    // MARK: Contains NONE of the elements as values.
+    func testContainsNoValuesOf() {
+        // Variadic parameters.
+        XCTAssertTrue(containsNoValuesOf(values: .init(g: 1), .init(g: 3)).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertFalse(containsNoValuesOf(values: .init(g: 1), .init(g: 3)).matches([1, 2].toDictionaryAsKeysWithEquatable()))
+        XCTAssertTrue(containsNoValuesOf(values: .init(g: 1), .init(g: 3), where: { $0.g == $1.g }).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertFalse(containsNoValuesOf(values: .init(g: 1), .init(g: 3)).matches([1, 3].toDictionaryAsKeysWithEquatable()))
+        XCTAssertFalse(containsNoValuesOf(values: .init(g: 1), .init(g: 3)).matches([1, 2, 3].toDictionaryAsKeysWithHashable()))
+
+        // Passed by array.
+        XCTAssertTrue(containsNoValuesOf([1, 3].map(TestStructs.H.init)).matches([2].toDictionaryAsKeysWithHashable()))
+        XCTAssertFalse(containsNoValuesOf([1, 3].map(TestStructs.E.init)).matches([1, 2].toDictionaryAsKeysWithEquatable()))
+        XCTAssertTrue(containsNoValuesOf([1, 3].map(TestStructs.N.init), where: { $0.g == $1.g }).matches([0, 2].toDictionaryAsKeysWithNonEquatable()))
+        XCTAssertFalse(containsNoValuesOf([1, 3].map(TestStructs.E.init)).matches([1, 3].toDictionaryAsKeysWithEquatable()))
+        XCTAssertFalse(containsNoValuesOf([1, 3].map(TestStructs.H.init)).matches([1, 2, 3].toDictionaryAsKeysWithHashable()))
+
+        XCTAssertFalse(
+            containsNoValuesOf([.init(g: 1), .init(g: 3)])
+                .matches([2: TestStructs.H(g: 3), 3: .init(g: 1)]))
+        XCTAssertFalse(
+            containsNoValuesOf([.init(g: 1), .init(g: 3)])
+                .matches([2: TestStructs.H(g: 3), 3: .init(g: 4)]))
+        XCTAssertFalse(
+            containsNoValuesOf([.init(g: 1), .init(g: 3)])
+                .matches([1: TestStructs.H(g: 3)]))
+        XCTAssertFalse(
+            containsNoValuesOf([.init(g: 1), .init(g: 3)])
+                .matches([1: TestStructs.H(g: 1)]))
+        XCTAssertTrue(
+            containsNoValuesOf([.init(g: 1), .init(g: 3)])
+                .matches([2: TestStructs.H(g: -3)]))
+    }
+
+    // MARK: Has length N (exact, at least, at most).
+    func testHasLengthExact() {
+        XCTAssertTrue(hasLength(exactly: 4).matches([1: 1, 2: 2, 3: 3, 4: 4]))
+        XCTAssertFalse(hasLength(exactly: 2).matches([1: 1, 2: 2, 3: 3, 4: 4]))
+        XCTAssertTrue(hasLength(exactly: 0).matches([:]))
+    }
+
+    func testHasLengthAtLeast() {
+        XCTAssertTrue(hasLength(atLeast: 4).matches([1: 1, 2: 2, 3: 3, 4: 4]))
+        XCTAssertTrue(hasLength(atLeast: 2).matches([1: 1, 2: 2, 3: 3, 4: 4]))
+        XCTAssertTrue(hasLength(atLeast: 0).matches([:]))
+
+        XCTAssertFalse(hasLength(atLeast: 4, inclusive: false).matches([1: 1, 2: 2, 3: 3, 4: 4]))
+        XCTAssertTrue(hasLength(atLeast: 2, inclusive: false).matches([1: 1, 2: 2, 3: 3, 4: 4]))
+        XCTAssertFalse(hasLength(atLeast: 0, inclusive: false).matches([:]))
+    }
+
+    func testHasLengthAtMost() {
+        XCTAssertTrue(hasLength(atMost: 4).matches([1: 1, 2: 2, 3: 3, 4: 4]))
+        XCTAssertFalse(hasLength(atMost: 2).matches([1: 1, 2: 2, 3: 3, 4: 4]))
+        XCTAssertTrue(hasLength(atMost: 0).matches([:]))
+
+        XCTAssertTrue(hasLength(atMost: 5, inclusive: false).matches([1, 2, 3, 4]))
+        XCTAssertFalse(hasLength(atMost: 2, inclusive: false).matches([1, 2, 3, 4]))
+        XCTAssertFalse(hasLength(atMost: 0, inclusive: false).matches([:]))
+    }
+}
+
+extension Array where Element == Int {
+    func toDictionaryAsKeysAndValues(_ constructor: (Int) -> (Int, Int) = { ($0, $0) }) -> [Int: Int] {
+        return Dictionary(uniqueKeysWithValues: map(constructor))
+    }
+
+    func toDictionaryAsKeysWithNonEquatable(_ constructor: (Int) -> (Int, TestStructs.N) = { ($0, TestStructs.N(g: $0)) }) -> [Int: TestStructs.N] {
+        return Dictionary(uniqueKeysWithValues: map(constructor))
+    }
+
+    func toDictionaryAsKeysWithEquatable(_ constructor: (Int) -> (Int, TestStructs.E) = { ($0, TestStructs.E(g: $0)) }) -> [Int: TestStructs.E] {
+        return Dictionary(uniqueKeysWithValues: map(constructor))
+    }
+
+    func toDictionaryAsKeysWithHashable(_ constructor: (Int) -> (Int, TestStructs.H) = { ($0, TestStructs.H(g: $0)) }) -> [Int: TestStructs.H] {
+        return Dictionary(uniqueKeysWithValues: map(constructor))
+    }
+}

--- a/Tests/Matching/ParameterMatcherTest.swift
+++ b/Tests/Matching/ParameterMatcherTest.swift
@@ -10,7 +10,6 @@ import XCTest
 import Cuckoo
 
 class ParameterMatcherTest: XCTestCase {
-    
     func testMatches() {
         let matcher = ParameterMatcher { $0 == 5 }
         
@@ -31,5 +30,15 @@ class ParameterMatcherTest: XCTestCase {
         
         XCTAssertTrue(matcher.matches(4))
         XCTAssertFalse(matcher.matches(3))
+    }
+
+    func testNot() {
+        let matcher = not(ParameterMatcher { $0 > 3 })
+
+        XCTAssertTrue(matcher.matches(3))
+        XCTAssertTrue(matcher.matches(2))
+        XCTAssertTrue(matcher.matches(-1))
+        XCTAssertFalse(matcher.matches(4))
+        XCTAssertFalse(matcher.matches(10))
     }
 }

--- a/Tests/Source/TestedClass.swift
+++ b/Tests/Source/TestedClass.swift
@@ -367,3 +367,17 @@ class TypeIsRightClass {
     var boolMaybeYes = true as Bool?
     var largeInty = 1_234_567
 }
+
+class ConvenienceMatchersAmbiguer {
+    func arrays(array a: [Int], array b: [String], array c: [Bool]) { }
+
+    // The methods' names are identical to find out ambiguity immediately if introduced.
+    func a(a: String) -> Bool { return true }
+    func a(a: [Int]) -> Bool { return true }
+    func a(a: [String]) -> Bool { return true }
+    func a(a: [Bool]) -> Bool { return true }
+    func a(a: [Int: Bool]) -> Bool { return true }
+    func a(a: [String: Bool]) -> Bool { return true }
+    func a(a: Set<String>) -> Bool { return true }
+    func a(a: Set<Bool>) -> Bool { return true }
+}


### PR DESCRIPTION
This PR also brings the ability to use concrete values instead of using the `equal(to:)` matcher when the elements are `Equatable`.