### PR TITLE
Switch swift_version to 5.0 and add LIBRARY_SEARCH_PATHS in xcconfig

### DIFF
--- a/Cuckoo.podspec
+++ b/Cuckoo.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   #s.watchos.deployment_target   = '2.0' # watchos does not include XCTest framework :(
   s.tvos.deployment_target      = '9.0'
   generator_name                = 'cuckoo_generator'
-  s.swift_version               = '4.2'
+  s.swift_version               = '5.0'
   s.preserve_paths              = ['Generator/**/*', 'run', 'build_generator', generator_name]
   s.prepare_command             = <<-CMD
                                     curl -Lo #{generator_name} https://github.com/Brightify/Cuckoo/releases/download/#{s.version}/#{generator_name}
@@ -30,6 +30,10 @@ Pod::Spec.new do |s|
   s.requires_arc                = true
   s.pod_target_xcconfig         = { 'ENABLE_BITCODE' => 'NO', 'SWIFT_REFLECTION_METADATA_LEVEL' => 'none' }
   s.default_subspec             = 'Swift'
+  
+  s.xcconfig = {
+    'LIBRARY_SEARCH_PATHS' => '$(TOOLCHAIN_DIR)/usr/lib/swift-$(SWIFT_VERSION)/$(PLATFORM_NAME) $(inherited)'
+  }
 
   s.subspec 'Swift' do |sub|
     sub.source_files = 'Source/**/*.swift'


### PR DESCRIPTION
This fixes running tests on iOS 10/11/12 with Cuckoo when tests are built using Xcode 11.

It is a minimal required fix. I checked this, nothing can be removed from these changes to fix the issue.

I think it is okay to switch to Swift 5 at the moment. It is the biggest change in terms of compatibility, it has stable ABI, etc. I was trying to keep my project in Swift 5, but I gave up after several days. You can make a tag named swift-4.2 for current HEAD in Cuckoo. People who use your project will still be able use your project.

I think there is no point in holding on to the past now.