### PR TITLE
Fix closure generation, return type is required in `withoutActuallyEs…

### DIFF
--- a/Generator/Source/CuckooGeneratorFramework/Generator.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Generator.swift
@@ -49,8 +49,11 @@ public struct Generator {
 
         ext.registerFilter("openNestedClosure") { (value: Any?, arguments: [Any?]) in
             guard let parameters = value as? [MethodParameter] else { return value }
-
-            let s = self.openNestedClosure(for: parameters, throwing: arguments.first as? Bool)
+            var returnType: String?
+            if arguments.count > 1 {
+              returnType = arguments[1] as? String
+            }
+            let s = self.openNestedClosure(for: parameters, throwing: arguments.first as? Bool, returnType: returnType)
             return s
         }
 
@@ -108,13 +111,15 @@ public struct Generator {
         return type.replacingOccurrences(of: "!", with: "?")
     }
 
-    private func openNestedClosure(for parameters: [MethodParameter], throwing: Bool? = false) -> String {
+    private func openNestedClosure(for parameters: [MethodParameter], throwing: Bool? = false, returnType: String?) -> String {
         var fullString = ""
         for (index, parameter) in parameters.enumerated() {
             if parameter.isClosure && !parameter.isEscaping {
                 let indents = String(repeating: "\t", count: index)
                 let tries = (throwing ?? false) ? " try " : " "
-                fullString += "\(indents)return\(tries)withoutActuallyEscaping(\(parameter.name), do: { (\(parameter.name): @escaping \(parameter.type)) in\n"
+                let returns = (returnType != nil) ? " -> \(returnType!)" : ""
+
+                fullString += "\(indents)return\(tries)withoutActuallyEscaping(\(parameter.name), do: { (\(parameter.name): @escaping \(parameter.type))\(returns) in\n"
             }
         }
         return fullString

--- a/Generator/Source/CuckooGeneratorFramework/Generator.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Generator.swift
@@ -49,12 +49,11 @@ public struct Generator {
 
         ext.registerFilter("openNestedClosure") { (value: Any?, arguments: [Any?]) in
             guard let parameters = value as? [MethodParameter] else { return value }
-            var returnType: String?
-            if arguments.count > 1 {
-              returnType = arguments[1] as? String
+            var returnType: WrappableType = WrappableType(parsing: "")
+            if arguments.count > 1, let unwrappedWrapableType = arguments[1] as? WrappableType {
+              returnType = unwrappedWrapableType
             }
-            let s = self.openNestedClosure(for: parameters, throwing: arguments.first as? Bool, returnType: returnType)
-            return s
+            return self.openNestedClosure(for: parameters, throwing: arguments.first as? Bool, returnType: returnType)
         }
 
         ext.registerFilter("closeNestedClosure") { (value: Any?) in
@@ -111,15 +110,18 @@ public struct Generator {
         return type.replacingOccurrences(of: "!", with: "?")
     }
 
-    private func openNestedClosure(for parameters: [MethodParameter], throwing: Bool? = false, returnType: String?) -> String {
+    private func openNestedClosure(for parameters: [MethodParameter], throwing: Bool? = false, returnType: WrappableType) -> String {
         var fullString = ""
         for (index, parameter) in parameters.enumerated() {
             if parameter.isClosure && !parameter.isEscaping {
                 let indents = String(repeating: "\t", count: index)
                 let tries = (throwing ?? false) ? " try " : " "
-                let returns = (returnType != nil) ? " -> \(returnType!)" : ""
+                var returnSignature = returnType.sugarized
+                if !returnSignature.isEmpty {
+                  returnSignature = " -> \(returnSignature)"
+                }
 
-                fullString += "\(indents)return\(tries)withoutActuallyEscaping(\(parameter.name), do: { (\(parameter.name): @escaping \(parameter.type))\(returns) in\n"
+                fullString += "\(indents)return\(tries)withoutActuallyEscaping(\(parameter.name), do: { (\(parameter.name): @escaping \(parameter.type))\(returnSignature) in\n"
             }
         }
         return fullString

--- a/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
@@ -103,7 +103,7 @@ extension Templates {
     {{ attribute.text }}
     {% endfor %}
     {{ method.accessibility }}{% if container.isImplementation and method.isOverriding %} override{% endif %} func {{ method.name }}{{ method.genericParameters }}({{ method.parameterSignature }}) {{ method.returnSignature }} {
-        {{ method.parameters|openNestedClosure:method.isThrowing }}
+        {{ method.parameters|openNestedClosure:method.isThrowing, :method.returnType }}
     return{% if method.isThrowing %} try{% endif %} cuckoo_manager.call{% if method.isThrowing %}{{ method.throwType|capitalize }}{% endif %}("{{method.fullyQualifiedName}}",
             parameters: ({{method.parameterNames}}),
             escapingParameters: ({{method.escapingParameterNames}}),

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Method.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Method.swift
@@ -105,8 +105,7 @@ public extension Method {
                     if !returnSignature.isEmpty {
                       if returnSignature != "Void" {
                         returnSignature = " -> " + returnSignature
-                      }
-                      else {
+                      } else {
                         returnSignature = ""
                       }
                     }
@@ -147,22 +146,25 @@ public extension Method {
             "genericParameters": isGeneric ? "<\(genericParametersString)>" : "",
         ]
     }
-  private func extractClosureReturnType(parameter: String) -> String? {
-    var openBracketCount = 0
-    var closeBracketCount = 0
-    for i : Int in 0..<parameter.count {
-      let index = parameter.index(parameter.startIndex, offsetBy: i)
-      if parameter[index] == "(" {
-        openBracketCount += 1
-      }
-      else if (parameter[index] == ")") {
-        closeBracketCount += 1
-        if openBracketCount == closeBracketCount {
-         let afterClosure = String(parameter[parameter.index(after: index)..<parameter.endIndex])
-         return afterClosure.matches(for: "\\s*->\\s*(.*)\\s*").first
+    private func extractClosureReturnType(parameter: String) -> String? {
+        var parentLevel = 0
+        for i in 0..<parameter.count {
+            let index = parameter.index(parameter.startIndex, offsetBy: i)
+            if parameter[index] == "(" {
+                parentLevel += 1
+            }
+            else if (parameter[index] == ")") {
+                parentLevel -= 1
+              if parentLevel == 0 {
+                    let afterClosure = String(parameter[parameter.index(after: index)..<parameter.endIndex])
+                    do {
+                        return try afterClosure.matches(for: "\\s*->\\s*(.*)\\s*").first
+                    } catch let error {
+                        fatalError("Invalid regex:" + error.localizedDescription)
+                    }
+                }
+            }
         }
-      }
+        return nil
     }
-    return nil
-  }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Method.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Method.swift
@@ -98,7 +98,13 @@ public extension Method {
             if parameter.isClosure && !parameter.isEscaping {
                 let parameterCount = parameter.closureParamCount
                 let parameterSignature = parameterCount > 0 ? (1...parameterCount).map { _ in "_" }.joined(separator: ", ") : "()"
-                return "{ \(parameterSignature) in fatalError(\"This is a stub! It's not supposed to be called!\") }"
+                var returns: String?
+
+                if !parameter.type.sugarized.isEmpty {
+                  returns = parameter.type.sugarized.components(separatedBy: "->").last
+                }
+
+                return "{ \(parameterSignature) \(returns != nil && returns != "Void" ? " -> \(returns!) " : "") in fatalError(\"This is a stub! It's not supposed to be called!\") }"
             } else {
                 return parameter.name
             }

--- a/Generator/Source/CuckooGeneratorFramework/Utils.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Utils.swift
@@ -18,15 +18,11 @@ extension String {
         return components(separatedBy: occurence).first
     }
 
-    func matches(for regex: String) -> [String] {
-      do {
+    func matches(for regex: String) throws -> [String] {
         let regex = try NSRegularExpression(pattern: regex)
         let nsString = self as NSString
         let results = regex.matches(in: self, range: NSRange(location: 0, length: nsString.length))
         return results.map { nsString.substring(with: $0.range(at: 1)) }
-      } catch {
-        return []
-      }
     }
 
     subscript(range: Range<Int>) -> String {

--- a/Generator/Source/CuckooGeneratorFramework/Utils.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Utils.swift
@@ -18,6 +18,17 @@ extension String {
         return components(separatedBy: occurence).first
     }
 
+    func matches(for regex: String) -> [String] {
+      do {
+        let regex = try NSRegularExpression(pattern: regex)
+        let nsString = self as NSString
+        let results = regex.matches(in: self, range: NSRange(location: 0, length: nsString.length))
+        return results.map { nsString.substring(with: $0.range(at: 1)) }
+      } catch {
+        return []
+      }
+    }
+
     subscript(range: Range<Int>) -> String {
         let stringRange = index(startIndex, offsetBy: range.lowerBound)..<index(startIndex, offsetBy: range.upperBound)
         return String(self[stringRange])

--- a/Tests/ClassTest.swift
+++ b/Tests/ClassTest.swift
@@ -153,10 +153,16 @@ class ClassTest: XCTestCase {
     func testWithClosure() {
         stub(mock) { mock in
             when(mock.withClosure(anyClosure())).then { $0("a") }
+            when(mock.withClosureReturnAVoidClosure(anyClosure())).then { $0("a")()}
+            when(mock.withClosureReturnAnIntClosure(anyClosure())).then { $0("a")(1)}
         }
 
         XCTAssertEqual(mock.withClosure { _ in 1 }, 1)
+        XCTAssertEqual(mock.withClosureReturnAVoidClosure {_ in { return 1 }}, 1)
+        XCTAssertEqual(mock.withClosureReturnAnIntClosure { _ in { _ in return 1} }, 1)
         verify(mock).withClosure(anyClosure())
+        verify(mock).withClosureReturnAVoidClosure(anyClosure())
+        verify(mock).withClosureReturnAnIntClosure(anyClosure())
     }
 
     func testWithEscape() {

--- a/Tests/ClassTest.swift
+++ b/Tests/ClassTest.swift
@@ -153,12 +153,12 @@ class ClassTest: XCTestCase {
     func testWithClosure() {
         stub(mock) { mock in
             when(mock.withClosure(anyClosure())).then { $0("a") }
-            when(mock.withClosureReturnAVoidClosure(anyClosure())).then { $0("a")()}
-            when(mock.withClosureReturnAnIntClosure(anyClosure())).then { $0("a")(1)}
+            when(mock.withClosureReturnAVoidClosure(anyClosure())).then { $0("a")() }
+            when(mock.withClosureReturnAnIntClosure(anyClosure())).then { $0("a")(1) }
         }
 
         XCTAssertEqual(mock.withClosure { _ in 1 }, 1)
-        XCTAssertEqual(mock.withClosureReturnAVoidClosure {_ in { return 1 }}, 1)
+        XCTAssertEqual(mock.withClosureReturnAVoidClosure {_ in { return 1 } }, 1)
         XCTAssertEqual(mock.withClosureReturnAnIntClosure { _ in { _ in return 1} }, 1)
         verify(mock).withClosure(anyClosure())
         verify(mock).withClosureReturnAVoidClosure(anyClosure())

--- a/Tests/Source/TestedClass.swift
+++ b/Tests/Source/TestedClass.swift
@@ -54,11 +54,11 @@ class TestedClass {
     }
 
     func withClosureReturnAVoidClosure(_ closure: (String) -> () -> Int) -> Int {
-      return closure("hello")()
+        return closure("hello")()
     }
 
     func withClosureReturnAnIntClosure(_ closure: (String) -> (Int) -> Int) -> Int {
-      return closure("hello")(3)
+        return closure("hello")(3)
     }
 
     func withEscape(_ a: String, action closure: @escaping (String) -> Void) {

--- a/Tests/Source/TestedClass.swift
+++ b/Tests/Source/TestedClass.swift
@@ -53,6 +53,14 @@ class TestedClass {
         return closure("hello")
     }
 
+    func withClosureReturnAVoidClosure(_ closure: (String) -> () -> Int) -> Int {
+      return closure("hello")()
+    }
+
+    func withClosureReturnAnIntClosure(_ closure: (String) -> (Int) -> Int) -> Int {
+      return closure("hello")(3)
+    }
+
     func withEscape(_ a: String, action closure: @escaping (String) -> Void) {
         closure(a)
     }


### PR DESCRIPTION
…caping` from swift 5.1 (XCode11) Brightify#313