### PR TITLE
Added option to prefix classnames of mocks and stubs

### DIFF
--- a/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
@@ -7,7 +7,7 @@
 
 extension Templates {
     static let noImplStub = """
-{{container.accessibility}} class {{ container.name }}Stub{{ container.genericParameters }}: {{ container.name }}{% if container.isImplementation %}{{ container.genericArguments }}{% endif %} {
+{{container.accessibility}} class {{ container.stubName }}{{ container.genericParameters }}: {{ container.name }}{% if container.isImplementation %}{{ container.genericArguments }}{% endif %} {
     {% for property in container.properties %}
     {% for attribute in property.attributes %}
     {{ attribute.text }}

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -13,11 +13,12 @@ public struct Tokenizer {
     private let file: File
     private let source: String
     private let debugMode: Bool
+    private let prefix: String
 
-    public init(sourceFile: File, debugMode: Bool) {
+    public init(sourceFile: File, debugMode: Bool, prefix: String) {
         self.file = sourceFile
         self.debugMode = debugMode
-
+        self.prefix = prefix
         source = sourceFile.contents
     }
 
@@ -101,6 +102,7 @@ public struct Tokenizer {
 
             return ProtocolDeclaration(
                 name: name,
+                prefix: prefix,
                 accessibility: accessibility,
                 range: range!,
                 nameRange: nameRange!,
@@ -126,6 +128,7 @@ public struct Tokenizer {
 
             return ClassDeclaration(
                 name: name,
+                prefix: prefix,
                 accessibility: accessibility,
                 range: range!,
                 nameRange: nameRange!,

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
@@ -9,6 +9,7 @@
 public struct ClassDeclaration: ContainerToken, HasAccessibility {
     public let implementation: Bool = true
     public var name: String
+    public var prefix: String
     public var accessibility: Accessibility
     public var range: CountableRange<Int>
     public var nameRange: CountableRange<Int>
@@ -25,6 +26,7 @@ public struct ClassDeclaration: ContainerToken, HasAccessibility {
     public func replace(children tokens: [Token]) -> ClassDeclaration {
         return ClassDeclaration(
             name: self.name,
+            prefix: self.prefix,
             accessibility: self.accessibility,
             range: self.range,
             nameRange: self.nameRange,

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
@@ -8,6 +8,7 @@
 
 public protocol ContainerToken: Token, HasAccessibility {
     var name: String { get }
+    var prefix: String { get }
     var range: CountableRange<Int> { get }
     var nameRange: CountableRange<Int> { get }
     var bodyRange: CountableRange<Int> { get }
@@ -47,7 +48,8 @@ extension ContainerToken {
             "methods": methods,
             "initializers": implementation ? [] : initializers,
             "isImplementation": implementation,
-            "mockName": "Mock\(name)",
+            "mockName": "\(prefix)Mock\(name)",
+            "stubName": "\(prefix)\(name)Stub",
             "inheritedTypes": inheritedTypes,
             "attributes": attributes.filter { $0.isSupported },
             "isGeneric": isGeneric,

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
@@ -9,6 +9,7 @@
 public struct ProtocolDeclaration: ContainerToken, HasAccessibility {
     public let implementation: Bool = false
     public var name: String
+    public var prefix: String
     public var accessibility: Accessibility
     public var range: CountableRange<Int>
     public var nameRange: CountableRange<Int>
@@ -22,6 +23,7 @@ public struct ProtocolDeclaration: ContainerToken, HasAccessibility {
     public func replace(children tokens: [Token]) -> ProtocolDeclaration {
         return ProtocolDeclaration(
             name: self.name,
+            prefix: self.prefix,
             accessibility: self.accessibility,
             range: self.range,
             nameRange: self.nameRange,

--- a/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
+++ b/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
@@ -13,12 +13,12 @@ import FileKit
 import CuckooGeneratorFramework
 import Foundation
 
-private func curry<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R>
-    (_ f: @escaping (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R)
-    -> (P1) -> (P2) -> (P3) -> (P4) -> (P5) -> (P6) -> (P7) -> (P8) -> (P9) -> (P10) -> (P11) -> (P12) -> R {
-        return { p1 in { p2 in { p3 in { p4 in { p5 in { p6 in { p7 in { p8 in { p9 in { p10 in { p11 in { p12 in
-            f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
-        } } } } } } } } } } } }
+private func curry<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, R>
+    (_ f: @escaping (P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) -> R)
+    -> (P1) -> (P2) -> (P3) -> (P4) -> (P5) -> (P6) -> (P7) -> (P8) -> (P9) -> (P10) -> (P11) -> (P12) -> (P13) -> R {
+        return { p1 in { p2 in { p3 in { p4 in { p5 in { p6 in { p7 in { p8 in { p9 in { p10 in { p11 in { p12 in { p13 in
+            f(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
+            } } } } } } } } } } } } }
 }
 
 public struct GenerateMocksCommand: CommandProtocol {
@@ -37,7 +37,7 @@ public struct GenerateMocksCommand: CommandProtocol {
             inputPathValues = getFullPathSortedArray(options.files)
         }
         let inputFiles = inputPathValues.map { File(path: $0) }.compactMap { $0 }
-        let tokens = inputFiles.map { Tokenizer(sourceFile: $0, debugMode: options.debugMode).tokenize() }
+        let tokens = inputFiles.map { Tokenizer(sourceFile: $0, debugMode: options.debugMode, prefix: options.classPrefix).tokenize() }
         let tokensWithInheritance = options.noInheritance ? tokens : mergeInheritance(tokens)
 
         // filter classes/protocols based on the settings passed to the generator
@@ -137,6 +137,7 @@ public struct GenerateMocksCommand: CommandProtocol {
         let testableFrameworks: [String]
         let exclude: [String]
         let filePrefix: String
+        let classPrefix: String
         let noClassMocking: Bool
         let debugMode: Bool
         let globEnabled: Bool
@@ -149,6 +150,7 @@ public struct GenerateMocksCommand: CommandProtocol {
                     noTimestamp: Bool,
                     noInheritance: Bool,
                     filePrefix: String,
+                    classPrefix: String,
                     noClassMocking: Bool,
                     debugMode: Bool,
                     globEnabled: Bool,
@@ -162,6 +164,7 @@ public struct GenerateMocksCommand: CommandProtocol {
             self.noTimestamp = noTimestamp
             self.noInheritance = noInheritance
             self.filePrefix = filePrefix
+            self.classPrefix = classPrefix
             self.noClassMocking = noClassMocking
             self.debugMode = debugMode
             self.globEnabled = globEnabled
@@ -185,6 +188,8 @@ public struct GenerateMocksCommand: CommandProtocol {
 
             let filePrefix: Result<String, CommandantError<ClientError>> = m <| Option(key: "file-prefix", defaultValue: "", usage: "Names of generated files in directory will start with this prefix. Only works when output path is directory.")
 
+            let classPrefix: Result<String, CommandantError<ClientError>> = m <| Option(key: "class-prefix", defaultValue: "", usage: "Names of generated classes will start with this prefix.")
+
             let noClassMocking: Result<Bool, CommandantError<ClientError>> = m <| Option(key: "no-class-mocking", defaultValue: false, usage: "Do not generate mocks for classes.")
 
             let debugMode: Result<Bool, CommandantError<ClientError>> = m <| Switch(flag: "d", key: "debug", usage: "Run generator in debug mode.")
@@ -203,6 +208,7 @@ public struct GenerateMocksCommand: CommandProtocol {
                 <*> noTimestamp
                 <*> noInheritance
                 <*> filePrefix
+                <*> classPrefix
                 <*> noClassMocking
                 <*> debugMode
                 <*> globEnabled

--- a/README.md
+++ b/README.md
@@ -461,6 +461,9 @@ Do not mock/stub parents and grandparents.
 ###### `--file-prefix` (string)
 Names of generated files in directory will start with this prefix. Only works when output path is directory.
 
+###### `--class-prefix` (string)
+Names of generated classes (Mocks and Stubs) will start with this prefix.
+
 ###### `--no-class-mocking`
 Do not generate mocks for classes.
 


### PR DESCRIPTION
Related to https://github.com/Brightify/Cuckoo/issues/321