### PR TITLE
Fail immediately if any command fails

### DIFF
--- a/build_generator
+++ b/build_generator
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 # getting the script directory: https://stackoverflow.com/a/246128
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 


### PR DESCRIPTION
I was having issues where the `swift build` command was failing but the script itself wouldn't fail. Using `set -e` will cause the shell script to immediately stop and exit if any command in the script itself fails.