### PR TITLE
Support Sequence Type result OCMock extension

### DIFF
--- a/OCMock/StubRecorder.swift
+++ b/OCMock/StubRecorder.swift
@@ -83,3 +83,19 @@ public extension StubRecorder where OUT: CuckooOptionalType, OUT.Wrapped: NSObje
         }
     }
 }
+
+public extension StubRecorder where OUT: Sequence, OUT.Element: NSObject {
+    func thenReturn(_ object: OUT) {
+        recorder.andReturn(object)
+    }
+
+    func then(do block: @escaping ([Any]) -> OUT) {
+        recorder.andDo { invocation in
+            guard let invocation = invocation else { return }
+
+            var result = block(invocation.arguments())
+            invocation.setReturnValue(&result)
+            invocation.retainArguments()
+        }
+    }
+}

--- a/Tests/OCMock/ObjectiveClassTest.swift
+++ b/Tests/OCMock/ObjectiveClassTest.swift
@@ -20,18 +20,20 @@ class ObjectiveClassTest: XCTestCase {
     }
 
     func testThenReturn() {
+        let subViews = [UIView()]
         let mock = objcStub(for: UIView.self) { stubber, mock in
             stubber.when(mock.endEditing(true)).thenReturn(true)
             stubber.when(mock.endEditing(false)).thenReturn(false)
-            stubber.when(mock.subviews).thenReturn([UIView]())
+            stubber.when(mock.subviews).thenReturn(subViews)
         }
 
         XCTAssertTrue(mock.endEditing(true))
         XCTAssertFalse(mock.endEditing(false))
-        XCTAssertTrue(mock.subviews.isEmpty)
+        XCTAssertEqual(mock.subviews,subViews)
         
         objcVerify(mock.endEditing(true))
         objcVerify(mock.endEditing(false))
+        objcVerify(mock.subviews)
     }
 
     func testThen() {

--- a/Tests/OCMock/ObjectiveClassTest.swift
+++ b/Tests/OCMock/ObjectiveClassTest.swift
@@ -23,11 +23,13 @@ class ObjectiveClassTest: XCTestCase {
         let mock = objcStub(for: UIView.self) { stubber, mock in
             stubber.when(mock.endEditing(true)).thenReturn(true)
             stubber.when(mock.endEditing(false)).thenReturn(false)
+            stubber.when(mock.subviews).thenReturn([UIView]())
         }
 
         XCTAssertTrue(mock.endEditing(true))
         XCTAssertFalse(mock.endEditing(false))
-
+        XCTAssertTrue(mock.subviews.isEmpty)
+        
         objcVerify(mock.endEditing(true))
         objcVerify(mock.endEditing(false))
     }


### PR DESCRIPTION
Support for like that code.

```
let locMock = objcStub(for: CLLocationManager.self) { stubber, mock in
            stubber.when(mock.monitoredRegions).thenReturn(Set<CLRegion>())
        }
```