### PR TITLE
Exits with exit code 1 on input file not found

### DIFF
--- a/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
+++ b/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
@@ -36,7 +36,10 @@ public struct GenerateMocksCommand: CommandProtocol {
         } else {
             inputPathValues = getFullPathSortedArray(options.files)
         }
-        let inputFiles = inputPathValues.map { File(path: $0) }.compactMap { $0 }
+        let inputFiles = inputPathValues.compactMap { File(path: $0) }
+        if inputPathValues.count != inputFiles.count {
+            exit(1)
+        }
         let tokens = inputFiles.map { Tokenizer(sourceFile: $0, debugMode: options.debugMode).tokenize() }
         let tokensWithInheritance = options.noInheritance ? tokens : mergeInheritance(tokens)
 


### PR DESCRIPTION
Forces the generator to exit with exit code 1 when input files aren't found. This will cause the xcode build to stop if files aren't found.
Resolves #297 