### PR TITLE
Allow verify to specify return type for generic functions

### DIFF
--- a/Cuckoo.xcodeproj/project.pbxproj
+++ b/Cuckoo.xcodeproj/project.pbxproj
@@ -83,6 +83,8 @@
 		277266573087574C196FE840 /* CallMatcherFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC319F6F55C00CFD3D0AF96 /* CallMatcherFunctions.swift */; };
 		2794938C670EBC6DD5B724BE /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE4758812545462B94DAB7A4 /* Stub.swift */; };
 		279670BCE126CBCD5FAFA463 /* StubThrowingFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808091A975F4E8BDDF0C80D9 /* StubThrowingFunction.swift */; };
+		27BCAB9824D4747E00EAAB55 /* GeneratedMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68472F9924D3ECA600E096C6 /* GeneratedMocks.swift */; };
+		27BCABAF24D474CD00EAAB55 /* GeneratedMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68472F9924D3ECA600E096C6 /* GeneratedMocks.swift */; };
 		2815413A02C4D193FB9296FC /* StubbingProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A9BEFC601EF66DF42D5022 /* StubbingProxy.swift */; };
 		283F668C4BDE15F7B7DA8D63 /* StringProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BA242F7A830953CD5E4AC4A /* StringProxy.m */; };
 		28EEBD56103D2CC8CF7A9149 /* VerifyReadOnlyProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A08AF20C937EF4EB98795B /* VerifyReadOnlyProperty.swift */; };
@@ -2314,6 +2316,7 @@
 				A98B094AF56BE63E7E4D2164 /* ParameterMatcherTest.swift in Sources */,
 				85BB583C1F89B50DC88999F2 /* ProtocolTest.swift in Sources */,
 				BC428931E53499C0EFDC802F /* ClassForStubTesting.swift in Sources */,
+				27BCAB9824D4747E00EAAB55 /* GeneratedMocks.swift in Sources */,
 				39B67C20D2A61BF2376634F3 /* ClassWithOptionals.swift in Sources */,
 				4A91D2B262ED9EC2EAC65D85 /* ExcludedTestClass.swift in Sources */,
 				BA6739666F5DDC4ADA564E2C /* GenericClass.swift in Sources */,
@@ -2637,6 +2640,7 @@
 				453EA0CE5ABEA62595596C6F /* ParameterMatcherTest.swift in Sources */,
 				63E990EB0DEE6A4873F30538 /* ProtocolTest.swift in Sources */,
 				A977B902CD0127BCD5BD272F /* ClassForStubTesting.swift in Sources */,
+				27BCABAF24D474CD00EAAB55 /* GeneratedMocks.swift in Sources */,
 				F09C7E5B6AD4AEB0166F871F /* ClassWithOptionals.swift in Sources */,
 				8B704B099E1FEA7F97ECEAE0 /* ExcludedTestClass.swift in Sources */,
 				68666AF31756DE755BED16A0 /* GenericClass.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -298,6 +298,16 @@ Verification of properties is similar to their stubbing.
 
 You can check if there are no more interactions on mock with function `verifyNoMoreInteractions`.
 
+With swift's generic types, it is possible to have a generic method who's type is determined by the type of its return value. To be able to verify these methods, you need to be able to specify the return type.
+
+```Swift
+// Given:
+func genericReturn<T: Codable>(for: String) -> T? { ... }
+
+// Verify
+verify(mock).genericReturn(for: any()).with(returnType: String?.self)
+```
+
 ##### Argument capture
 You can use `ArgumentCaptor` to capture arguments in verification of calls (doing that in stubbing is not recommended). Here is an example code:
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Verification of properties is similar to their stubbing.
 
 You can check if there are no more interactions on mock with function `verifyNoMoreInteractions`.
 
-With Swift's generic types, it is possible to use a generic parameter as the returned type. To properly verify these methods, you need to be able to specify the return type.
+With Swift's generic types, it is possible to use a generic parameter as the return type. To properly verify these methods, you need to be able to specify the return type.
 
 ```Swift
 // Given:

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Verification of properties is similar to their stubbing.
 
 You can check if there are no more interactions on mock with function `verifyNoMoreInteractions`.
 
-With swift's generic types, it is possible to have a generic method who's type is determined by the type of its return value. To be able to verify these methods, you need to be able to specify the return type.
+With Swift's generic types, it is possible to use a generic parameter as the returned type. To properly verify these methods, you need to be able to specify the return type.
 
 ```Swift
 // Given:

--- a/Source/Verification/__DoNotUse.swift
+++ b/Source/Verification/__DoNotUse.swift
@@ -8,3 +8,10 @@
 
 /// Marker struct for use as a return type in verification.
 public struct __DoNotUse<IN, OUT> { }
+
+public extension __DoNotUse {
+
+    /// Hint at the return type when verifying a function where the function is generic
+    /// and the type is inferred from the return value
+    func with(returnType: OUT.Type) { }
+}

--- a/Tests/Swift/Source/GenericMethodClass.swift
+++ b/Tests/Swift/Source/GenericMethodClass.swift
@@ -41,4 +41,8 @@ class GenericMethodClass<T: CustomStringConvertible> {
     func moreRethrowing<UwU>(param: @escaping () throws -> UwU) rethrows -> UwU {
         return try param()
     }
+
+    func genericReturn<W: Codable>(_ string: String) -> W? {
+        return try? JSONDecoder().decode(W.self, from: string.data(using: .utf8)!)
+    }
 }

--- a/Tests/Swift/Verification/VerificationTest.swift
+++ b/Tests/Swift/Verification/VerificationTest.swift
@@ -47,4 +47,15 @@ class VerificationTest: XCTestCase {
         verify(mock).noReturn()
         verify(mock).count(characters: anyString())
     }
+
+    func testVerifyWithGenericReturn() {
+        let mock = MockGenericMethodClass<String>()
+        stub(mock) { mock in
+            when(mock.genericReturn(any())).thenReturn("")
+        }
+
+        let _: String? = mock.genericReturn("Foo")
+
+        verify(mock).genericReturn(equal(to: "Foo")).with(returnType: String?.self)
+    }
 }


### PR DESCRIPTION
Verify a function call where that function is generic and the type is inferred from the return value

Given a function:
```swift
class Coupon: Codable, Persistable { }

func get<T: Codable & Persistable>(forKey defaultName: String) -> T?
```
Where `get` is expected to return a `Coupon`:
```swift
verify(persistence).get(forKey: equal(to: "key"))
```
We get `Generic parameter 'T' could not be inferred`

Borrowing an idea from mockk, this allows you to specify the type being returned:
```swift
public extension __DoNotUse {
    func with(returnType: OUT.Type) { }
}
```

And we can now do:
```swift
verify(persistence).get(forKey: equal(to: "key")).with(returnType: Coupon?.self)
```

Fixes #345 