### PR TITLE
Add support for protocol generic parameters in `init`.

### DIFF
--- a/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
@@ -88,7 +88,7 @@ extension Templates {
     {% if debug %}
     // {{initializer}}
     {% endif %}
-    {{ initializer.accessibility }}{% if container.isImplementation %} override{% endif %}{% if initializer.@type == "ProtocolMethod" %} required{% endif %} init({{initializer.parameterSignature}}) {
+    {{ initializer.accessibility }}{% if container.isImplementation %} override{% endif %}{% if initializer.@type == "ProtocolMethod" %} required{% endif %} init{{ initializer.genericParameters }}({{ initializer.parameterSignature }}) {
         {% if container.isImplementation %}
         super.init({{initializer.call}})
         {% endif %}

--- a/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
@@ -23,7 +23,7 @@ extension Templates {
     {% endfor %}
 
     {% for initializer in container.initializers %}
-    {{ initializer.accessibility }}{% if container.@type == "ClassDeclaration" %} override{% endif %}{% if initializer.@type == "ProtocolMethod" %} required{%endif%} init({{initializer.parameterSignature}}) {
+    {{ initializer.accessibility }}{% if container.@type == "ClassDeclaration" %} override{% endif %}{% if initializer.@type == "ProtocolMethod" %} required{%endif%} init{{ initializer.genericParameters }}({{ initializer.parameterSignature }}) {
         {% if container.@type == "ClassDeclaration" %}
         super.init({{initializer.call}})
         {% endif %}

--- a/Generator/Source/CuckooGeneratorFramework/Templates/TypeErasureTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/TypeErasureTemplate.swift
@@ -33,7 +33,7 @@ extension Templates {
         }
         {% if container.initializers %}
         /// MARK:- ignored required initializers{% endif %}
-        {% for initializer in container.initializers %}{{ container.accessibility }} required init({{ initializer.parameterSignature }}) {
+        {% for initializer in container.initializers %}{{ container.accessibility }} required init{{ initializer.genericParameters }}({{ initializer.parameterSignature }}) {
             fatalError("`DefaultImplCaller` class is only used for calling default implementation and can't be initialized on its own.")
         }
         {% endfor %}

--- a/Tests/Swift/GenericProtocolTest.swift
+++ b/Tests/Swift/GenericProtocolTest.swift
@@ -15,7 +15,7 @@ private class GenericProtocolConformerClass<C: AnyObject, V>: GenericProtocol {
     let constant: Int = 0
     var optionalProperty: V?
 
-    required init(theC: C, theV: V) {
+    required init<F>(theC: C, theV: V, f: F) {
         readOnlyPropertyC = theC
         readWritePropertyV = theV
     }
@@ -58,7 +58,7 @@ private struct GenericProtocolConformerStruct<C: AnyObject, V>: GenericProtocol 
     let constant: Int = 0
     var optionalProperty: V?
 
-    init(theC: C, theV: V) {
+    init<F>(theC: C, theV: V, f: F) {
         readOnlyPropertyC = theC
         readWritePropertyV = theV
     }
@@ -81,7 +81,7 @@ private struct GenericProtocolConformerStruct<C: AnyObject, V>: GenericProtocol 
 class GenericProtocolTest: XCTestCase {
     private func createMock<V>(value: V) -> MockGenericProtocol<MockTestedClass, V> {
         let classy = MockTestedClass()
-        return MockGenericProtocol(theC: classy, theV: value)
+        return MockGenericProtocol(theC: classy, theV: value, f: 0)
     }
 
     func testReadOnlyProperty() {
@@ -144,7 +144,7 @@ class GenericProtocolTest: XCTestCase {
 
     func testModification() {
         let mock = createMock(value: ["EXTERMINATE!": "EXTERMINATE!!", "EXTERMINATE!!!": "EXTERMINATE!!!!"])
-        let original = GenericProtocolConformerClass(theC: MockTestedClass(), theV: ["Sir, may I help you?": "Nope, just lookin' 👀"])
+        let original = GenericProtocolConformerClass(theC: MockTestedClass(), theV: ["Sir, may I help you?": "Nope, just lookin' 👀"], f: "F")
         mock.enableDefaultImplementation(original)
         
         original.readWritePropertyV["Are you sure?"] = "Yeah, I'm just waiting for my wife."
@@ -163,7 +163,7 @@ class GenericProtocolTest: XCTestCase {
     // using: `enableDefaultImplementation(mutating:)` reflects the original's state at all times
     func testStructModification() {
         let mock = createMock(value: ["EXTERMINATE!": "EXTERMINATE!!", "EXTERMINATE!!!": "EXTERMINATE!!!!"])
-        var original = GenericProtocolConformerStruct(theC: MockTestedClass(), theV: ["Sir, may I help you?": "Nope, just lookin' 👀"])
+        var original = GenericProtocolConformerStruct(theC: MockTestedClass(), theV: ["Sir, may I help you?": "Nope, just lookin' 👀"], f: "F")
         mock.enableDefaultImplementation(mutating: &original)
 
         original.readWritePropertyV["Are you sure?"] = "Yeah, I'm just waiting for my wife."
@@ -181,7 +181,7 @@ class GenericProtocolTest: XCTestCase {
     //
     func testStructNonModification() {
         let mock = createMock(value: ["EXTERMINATE!": "EXTERMINATE!!", "EXTERMINATE!!!": "EXTERMINATE!!!!"])
-        var original = GenericProtocolConformerStruct(theC: MockTestedClass(), theV: ["Sir, may I help you?": "Nope, just lookin' 👀"])
+        var original = GenericProtocolConformerStruct(theC: MockTestedClass(), theV: ["Sir, may I help you?": "Nope, just lookin' 👀"], f: "F")
         mock.enableDefaultImplementation(original)
 
         original.readWritePropertyV["Are you sure?"] = "Yeah, I'm just waiting for my wife."

--- a/Tests/Swift/Source/GenericProtocol.swift
+++ b/Tests/Swift/Source/GenericProtocol.swift
@@ -17,7 +17,7 @@ protocol GenericProtocol {
     var constant: Int { get }
     var optionalProperty: V? { get set }
 
-    init(theC: C, theV: V)
+    init<F>(theC: C, theV: V, f: F)
 
     func callSomeC(theC: C) -> Int
     func callSomeV(theV: V) -> Int


### PR DESCRIPTION
Initiated by #362.

TODO:
- [ ] Add support for generic protocol methods.