### PR TITLE
Nested containers

### DIFF
--- a/Cuckoo.xcodeproj/project.pbxproj
+++ b/Cuckoo.xcodeproj/project.pbxproj
@@ -385,12 +385,6 @@
 		CADD144525157A23008C5EBB /* NestedSubclassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD144425157A23008C5EBB /* NestedSubclassTests.swift */; };
 		CADD144625157A23008C5EBB /* NestedSubclassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD144425157A23008C5EBB /* NestedSubclassTests.swift */; };
 		CADD144725157A23008C5EBB /* NestedSubclassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD144425157A23008C5EBB /* NestedSubclassTests.swift */; };
-		CADD146B25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD146A25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift */; };
-		CADD146C25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD146A25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift */; };
-		CADD146D25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD146A25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift */; };
-		CADD147B25158A44008C5EBB /* NestedPrivateClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD147A25158A44008C5EBB /* NestedPrivateClassTest.swift */; };
-		CADD147C25158A44008C5EBB /* NestedPrivateClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD147A25158A44008C5EBB /* NestedPrivateClassTest.swift */; };
-		CADD147D25158A44008C5EBB /* NestedPrivateClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD147A25158A44008C5EBB /* NestedPrivateClassTest.swift */; };
 		CADD148B25158A62008C5EBB /* NestedPrivateExtensionClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD148A25158A62008C5EBB /* NestedPrivateExtensionClass.swift */; };
 		CADD148C25158A62008C5EBB /* NestedPrivateExtensionClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD148A25158A62008C5EBB /* NestedPrivateExtensionClass.swift */; };
 		CADD148D25158A62008C5EBB /* NestedPrivateExtensionClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD148A25158A62008C5EBB /* NestedPrivateExtensionClass.swift */; };
@@ -899,8 +893,6 @@
 		CACDD7562515247100980F58 /* NestedInExtensionFromClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedInExtensionFromClass.swift; sourceTree = "<group>"; };
 		CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedExtensionClassTest.swift; sourceTree = "<group>"; };
 		CADD144425157A23008C5EBB /* NestedSubclassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedSubclassTests.swift; sourceTree = "<group>"; };
-		CADD146A25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedPrivateExtensionClassTest.swift; sourceTree = "<group>"; };
-		CADD147A25158A44008C5EBB /* NestedPrivateClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedPrivateClassTest.swift; sourceTree = "<group>"; };
 		CADD148A25158A62008C5EBB /* NestedPrivateExtensionClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedPrivateExtensionClass.swift; sourceTree = "<group>"; };
 		CADD149A25158B60008C5EBB /* NestedInPrivateNestedClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedInPrivateNestedClass.swift; sourceTree = "<group>"; };
 		CADD14DA25159143008C5EBB /* MultiNestedInNestedClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiNestedInNestedClass.swift; sourceTree = "<group>"; };
@@ -1245,8 +1237,6 @@
 				CADD144425157A23008C5EBB /* NestedSubclassTests.swift */,
 				CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */,
 				CADD156A2515AA83008C5EBB /* NestedStructExtensionClassTest.swift */,
-				CADD146A25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift */,
-				CADD147A25158A44008C5EBB /* NestedPrivateClassTest.swift */,
 				CADD151A2515937D008C5EBB /* MultiNestedClassTest.swift */,
 				CADD152A2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift */,
 				CADD153A2515A858008C5EBB /* MultiNestedExtensionClassTest.swift */,
@@ -2392,7 +2382,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CADD147C25158A44008C5EBB /* NestedPrivateClassTest.swift in Sources */,
 				E8CE88DD377BB4EE8233AAFB /* TestError.swift in Sources */,
 				4F490D8457B9919E2E6A05B0 /* ClassTest.swift in Sources */,
 				CADD151C2515937D008C5EBB /* MultiNestedClassTest.swift in Sources */,
@@ -2447,7 +2436,6 @@
 				9F315C759A53B4765706C631 /* StubbingTest.swift in Sources */,
 				C98DD2231948D6D9486E3C1C /* TestUtils.swift in Sources */,
 				83A5A8205205BF4D44F93CD0 /* ArgumentCaptorTest.swift in Sources */,
-				CADD146C25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift in Sources */,
 				CADD14DC25159143008C5EBB /* MultiNestedInNestedClass.swift in Sources */,
 				F191F17A741759B8031CB6D5 /* VerificationTest.swift in Sources */,
 				CACDD7682515249E00980F58 /* NestedExtensionClassTest.swift in Sources */,
@@ -2580,7 +2568,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CADD147B25158A44008C5EBB /* NestedPrivateClassTest.swift in Sources */,
 				827A670BF9391A7C01822AF1 /* TestError.swift in Sources */,
 				EAFA72896871E0A2629AC784 /* ClassTest.swift in Sources */,
 				CADD151B2515937D008C5EBB /* MultiNestedClassTest.swift in Sources */,
@@ -2635,7 +2622,6 @@
 				061991F996D7C014B67647A9 /* StubbingTest.swift in Sources */,
 				AB4D73B2AF7C45B055A0909E /* TestUtils.swift in Sources */,
 				6D9C4E09B9E0AC6BD5AED4DA /* ArgumentCaptorTest.swift in Sources */,
-				CADD146B25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift in Sources */,
 				CADD14DB25159143008C5EBB /* MultiNestedInNestedClass.swift in Sources */,
 				E28273B64BC1C3C73331A168 /* VerificationTest.swift in Sources */,
 				CACDD7672515249E00980F58 /* NestedExtensionClassTest.swift in Sources */,
@@ -2754,7 +2740,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CADD147D25158A44008C5EBB /* NestedPrivateClassTest.swift in Sources */,
 				116D8FBB03787C2D7F7C99CC /* TestError.swift in Sources */,
 				D477FC12C92D54376DA507B5 /* ClassTest.swift in Sources */,
 				CADD151D2515937D008C5EBB /* MultiNestedClassTest.swift in Sources */,
@@ -2809,7 +2794,6 @@
 				03393CDA9320B79B75A2DE1D /* StubbingTest.swift in Sources */,
 				B4CABEBF620374BC06D2823B /* TestUtils.swift in Sources */,
 				1B425DF3B416C5E4FA04532C /* ArgumentCaptorTest.swift in Sources */,
-				CADD146D25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift in Sources */,
 				CADD14DD25159143008C5EBB /* MultiNestedInNestedClass.swift in Sources */,
 				F713219CB9579070209F289B /* VerificationTest.swift in Sources */,
 				CACDD7692515249E00980F58 /* NestedExtensionClassTest.swift in Sources */,

--- a/Cuckoo.xcodeproj/project.pbxproj
+++ b/Cuckoo.xcodeproj/project.pbxproj
@@ -397,6 +397,21 @@
 		CADD149B25158B60008C5EBB /* NestedInPrivateNestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD149A25158B60008C5EBB /* NestedInPrivateNestedClass.swift */; };
 		CADD149C25158B60008C5EBB /* NestedInPrivateNestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD149A25158B60008C5EBB /* NestedInPrivateNestedClass.swift */; };
 		CADD149D25158B60008C5EBB /* NestedInPrivateNestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD149A25158B60008C5EBB /* NestedInPrivateNestedClass.swift */; };
+		CADD14DB25159143008C5EBB /* MultiNestedInNestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD14DA25159143008C5EBB /* MultiNestedInNestedClass.swift */; };
+		CADD14DC25159143008C5EBB /* MultiNestedInNestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD14DA25159143008C5EBB /* MultiNestedInNestedClass.swift */; };
+		CADD14DD25159143008C5EBB /* MultiNestedInNestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD14DA25159143008C5EBB /* MultiNestedInNestedClass.swift */; };
+		CADD14EB25159168008C5EBB /* MultiNestedPrivateExtensionClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD14EA25159168008C5EBB /* MultiNestedPrivateExtensionClass.swift */; };
+		CADD14EC25159168008C5EBB /* MultiNestedPrivateExtensionClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD14EA25159168008C5EBB /* MultiNestedPrivateExtensionClass.swift */; };
+		CADD14ED25159168008C5EBB /* MultiNestedPrivateExtensionClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD14EA25159168008C5EBB /* MultiNestedPrivateExtensionClass.swift */; };
+		CADD14FB2515918B008C5EBB /* MultiNestedInPrivateNestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD14FA2515918B008C5EBB /* MultiNestedInPrivateNestedClass.swift */; };
+		CADD14FC2515918B008C5EBB /* MultiNestedInPrivateNestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD14FA2515918B008C5EBB /* MultiNestedInPrivateNestedClass.swift */; };
+		CADD14FD2515918B008C5EBB /* MultiNestedInPrivateNestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD14FA2515918B008C5EBB /* MultiNestedInPrivateNestedClass.swift */; };
+		CADD150B251591D8008C5EBB /* MultiNestedInExtensionFromClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD150A251591D8008C5EBB /* MultiNestedInExtensionFromClass.swift */; };
+		CADD150C251591D8008C5EBB /* MultiNestedInExtensionFromClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD150A251591D8008C5EBB /* MultiNestedInExtensionFromClass.swift */; };
+		CADD150D251591D8008C5EBB /* MultiNestedInExtensionFromClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD150A251591D8008C5EBB /* MultiNestedInExtensionFromClass.swift */; };
+		CADD151B2515937D008C5EBB /* MultiNestedClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD151A2515937D008C5EBB /* MultiNestedClassTest.swift */; };
+		CADD151C2515937D008C5EBB /* MultiNestedClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD151A2515937D008C5EBB /* MultiNestedClassTest.swift */; };
+		CADD151D2515937D008C5EBB /* MultiNestedClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD151A2515937D008C5EBB /* MultiNestedClassTest.swift */; };
 		CBB7017EE143A38098AD7287 /* GenericMethodClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B965102D09D6B0E94CDA8EA /* GenericMethodClassTest.swift */; };
 		CC2BA5A130CB61216E489D99 /* VerifyProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753FC6D19235B2C8F2DBAA7B /* VerifyProperty.swift */; };
 		CC60D01D5BD4771A8EC08F6A /* CreateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44692276AAFF9261EDD5D75 /* CreateMock.swift */; };
@@ -873,6 +888,11 @@
 		CADD147A25158A44008C5EBB /* NestedPrivateClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedPrivateClassTest.swift; sourceTree = "<group>"; };
 		CADD148A25158A62008C5EBB /* NestedPrivateExtensionClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedPrivateExtensionClass.swift; sourceTree = "<group>"; };
 		CADD149A25158B60008C5EBB /* NestedInPrivateNestedClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedInPrivateNestedClass.swift; sourceTree = "<group>"; };
+		CADD14DA25159143008C5EBB /* MultiNestedInNestedClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiNestedInNestedClass.swift; sourceTree = "<group>"; };
+		CADD14EA25159168008C5EBB /* MultiNestedPrivateExtensionClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiNestedPrivateExtensionClass.swift; sourceTree = "<group>"; };
+		CADD14FA2515918B008C5EBB /* MultiNestedInPrivateNestedClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiNestedInPrivateNestedClass.swift; sourceTree = "<group>"; };
+		CADD150A251591D8008C5EBB /* MultiNestedInExtensionFromClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiNestedInExtensionFromClass.swift; sourceTree = "<group>"; };
+		CADD151A2515937D008C5EBB /* MultiNestedClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiNestedClassTest.swift; sourceTree = "<group>"; };
 		CB65661C2188A3E830EEBF72 /* ThreadLocal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadLocal.swift; sourceTree = "<group>"; };
 		CEBE505B4B98BE6289678CD1 /* MatchableTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchableTest.swift; sourceTree = "<group>"; };
 		D09B97C65DA87366B8605109 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
@@ -1205,6 +1225,7 @@
 				CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */,
 				CADD146A25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift */,
 				CADD147A25158A44008C5EBB /* NestedPrivateClassTest.swift */,
+				CADD151A2515937D008C5EBB /* MultiNestedClassTest.swift */,
 				6873C8013002AFEA7565BDAC /* ClassTest.swift */,
 				8CDB969240E4E2B12FF93284 /* CollisionClasses.swift */,
 				0BEF42DC82FC0EF50E83E6CA /* CuckooFunctionsTest.swift */,
@@ -1284,6 +1305,10 @@
 				CADD148A25158A62008C5EBB /* NestedPrivateExtensionClass.swift */,
 				CADD149A25158B60008C5EBB /* NestedInPrivateNestedClass.swift */,
 				CACDD7562515247100980F58 /* NestedInExtensionFromClass.swift */,
+				CADD14DA25159143008C5EBB /* MultiNestedInNestedClass.swift */,
+				CADD14EA25159168008C5EBB /* MultiNestedPrivateExtensionClass.swift */,
+				CADD14FA2515918B008C5EBB /* MultiNestedInPrivateNestedClass.swift */,
+				CADD150A251591D8008C5EBB /* MultiNestedInExtensionFromClass.swift */,
 				55DE1954C1D6E94F2911830A /* ClassForStubTesting.swift */,
 				32A299482E4D2B7B774373A1 /* ClassWithOptionals.swift */,
 				FB36E482FF288D775B744A02 /* ExcludedTestClass.swift */,
@@ -2345,7 +2370,9 @@
 				CADD147C25158A44008C5EBB /* NestedPrivateClassTest.swift in Sources */,
 				E8CE88DD377BB4EE8233AAFB /* TestError.swift in Sources */,
 				4F490D8457B9919E2E6A05B0 /* ClassTest.swift in Sources */,
+				CADD151C2515937D008C5EBB /* MultiNestedClassTest.swift in Sources */,
 				BBA5EEAD87D96D3B15C78757 /* CollisionClasses.swift in Sources */,
+				CADD14EC25159168008C5EBB /* MultiNestedPrivateExtensionClass.swift in Sources */,
 				CADD149C25158B60008C5EBB /* NestedInPrivateNestedClass.swift in Sources */,
 				5290A06644BA9B7046E81643 /* CuckooFunctionsTest.swift in Sources */,
 				928FE5CCF9DEBC62FACF4C46 /* DefaultValueRegistryTest.swift in Sources */,
@@ -2372,6 +2399,7 @@
 				39B67C20D2A61BF2376634F3 /* ClassWithOptionals.swift in Sources */,
 				4A91D2B262ED9EC2EAC65D85 /* ExcludedTestClass.swift in Sources */,
 				BA6739666F5DDC4ADA564E2C /* GenericClass.swift in Sources */,
+				CADD150C251591D8008C5EBB /* MultiNestedInExtensionFromClass.swift in Sources */,
 				F2048BABD17B13EB53D9FB28 /* GenericMethodClass.swift in Sources */,
 				00E2BA604E1E453D285A420D /* GenericProtocol.swift in Sources */,
 				976C2EBAEC277E931B3AB769 /* ObjcProtocol.swift in Sources */,
@@ -2382,6 +2410,7 @@
 				DAD4C161978D36BCC64AB3C6 /* UnicodeTestProtocol.swift in Sources */,
 				6EF5C570D1E9D58B9F2DF865 /* StubTest.swift in Sources */,
 				A60190967F7ABAC6EEEBEAD0 /* StubFunctionTest.swift in Sources */,
+				CADD14FC2515918B008C5EBB /* MultiNestedInPrivateNestedClass.swift in Sources */,
 				E37116F9692A45F7ECF6E8EA /* StubNoReturnFunctionTest.swift in Sources */,
 				3A558B4AEDCF3278D13FCD88 /* StubNoReturnThrowingFunctionTest.swift in Sources */,
 				968F5345D4C4CEE2E7CA7F33 /* StubThrowingFunctionTest.swift in Sources */,
@@ -2389,6 +2418,7 @@
 				C98DD2231948D6D9486E3C1C /* TestUtils.swift in Sources */,
 				83A5A8205205BF4D44F93CD0 /* ArgumentCaptorTest.swift in Sources */,
 				CADD146C25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift in Sources */,
+				CADD14DC25159143008C5EBB /* MultiNestedInNestedClass.swift in Sources */,
 				F191F17A741759B8031CB6D5 /* VerificationTest.swift in Sources */,
 				CACDD7682515249E00980F58 /* NestedExtensionClassTest.swift in Sources */,
 			);
@@ -2523,7 +2553,9 @@
 				CADD147B25158A44008C5EBB /* NestedPrivateClassTest.swift in Sources */,
 				827A670BF9391A7C01822AF1 /* TestError.swift in Sources */,
 				EAFA72896871E0A2629AC784 /* ClassTest.swift in Sources */,
+				CADD151B2515937D008C5EBB /* MultiNestedClassTest.swift in Sources */,
 				E2D62D3393599003755F59F6 /* CollisionClasses.swift in Sources */,
+				CADD14EB25159168008C5EBB /* MultiNestedPrivateExtensionClass.swift in Sources */,
 				CADD149B25158B60008C5EBB /* NestedInPrivateNestedClass.swift in Sources */,
 				F25919FEF1D3A359CA975AAE /* CuckooFunctionsTest.swift in Sources */,
 				F22196061D37E66590633818 /* DefaultValueRegistryTest.swift in Sources */,
@@ -2550,6 +2582,7 @@
 				F52EE531052666CFB50523E6 /* ClassWithOptionals.swift in Sources */,
 				8AEC76DECB68343825159FB1 /* ExcludedTestClass.swift in Sources */,
 				5EE0A57E2B90191B395C84E8 /* GenericClass.swift in Sources */,
+				CADD150B251591D8008C5EBB /* MultiNestedInExtensionFromClass.swift in Sources */,
 				BA5FFE5076C1E8B3CD590D77 /* GenericMethodClass.swift in Sources */,
 				3F65D111D17BD0FADEF199CC /* GenericProtocol.swift in Sources */,
 				7E628E0FB6B59C6B641AF6B1 /* ObjcProtocol.swift in Sources */,
@@ -2560,6 +2593,7 @@
 				0ED1CB69A10271E8108F20FE /* UnicodeTestProtocol.swift in Sources */,
 				3986ACF12E0726C77025D550 /* StubTest.swift in Sources */,
 				BB2E89CC430EFA7009FFFD47 /* StubFunctionTest.swift in Sources */,
+				CADD14FB2515918B008C5EBB /* MultiNestedInPrivateNestedClass.swift in Sources */,
 				F23C1AB2E119F8427D5AA0F2 /* StubNoReturnFunctionTest.swift in Sources */,
 				4107AB080C2B17D1DC212ADC /* StubNoReturnThrowingFunctionTest.swift in Sources */,
 				9368231E7428DF22BAE3AEE9 /* StubThrowingFunctionTest.swift in Sources */,
@@ -2567,6 +2601,7 @@
 				AB4D73B2AF7C45B055A0909E /* TestUtils.swift in Sources */,
 				6D9C4E09B9E0AC6BD5AED4DA /* ArgumentCaptorTest.swift in Sources */,
 				CADD146B25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift in Sources */,
+				CADD14DB25159143008C5EBB /* MultiNestedInNestedClass.swift in Sources */,
 				E28273B64BC1C3C73331A168 /* VerificationTest.swift in Sources */,
 				CACDD7672515249E00980F58 /* NestedExtensionClassTest.swift in Sources */,
 			);
@@ -2687,7 +2722,9 @@
 				CADD147D25158A44008C5EBB /* NestedPrivateClassTest.swift in Sources */,
 				116D8FBB03787C2D7F7C99CC /* TestError.swift in Sources */,
 				D477FC12C92D54376DA507B5 /* ClassTest.swift in Sources */,
+				CADD151D2515937D008C5EBB /* MultiNestedClassTest.swift in Sources */,
 				023F8564E2E6BDC0C3740D15 /* CollisionClasses.swift in Sources */,
+				CADD14ED25159168008C5EBB /* MultiNestedPrivateExtensionClass.swift in Sources */,
 				CADD149D25158B60008C5EBB /* NestedInPrivateNestedClass.swift in Sources */,
 				1DB1CBFA2D7B012C81B1312B /* CuckooFunctionsTest.swift in Sources */,
 				2E54AB548933FF3D2F7E1384 /* DefaultValueRegistryTest.swift in Sources */,
@@ -2714,6 +2751,7 @@
 				F09C7E5B6AD4AEB0166F871F /* ClassWithOptionals.swift in Sources */,
 				8B704B099E1FEA7F97ECEAE0 /* ExcludedTestClass.swift in Sources */,
 				68666AF31756DE755BED16A0 /* GenericClass.swift in Sources */,
+				CADD150D251591D8008C5EBB /* MultiNestedInExtensionFromClass.swift in Sources */,
 				74D3B95277DBED7324B72ADA /* GenericMethodClass.swift in Sources */,
 				1C26D4A759E527279D1C431D /* GenericProtocol.swift in Sources */,
 				610B9F6B3C52E7241A80FC27 /* ObjcProtocol.swift in Sources */,
@@ -2724,6 +2762,7 @@
 				9B54EA8552637FBD7476E0A7 /* UnicodeTestProtocol.swift in Sources */,
 				25D818649F9686990D6E25AF /* StubTest.swift in Sources */,
 				13A6FF70A68C12E237C85B4C /* StubFunctionTest.swift in Sources */,
+				CADD14FD2515918B008C5EBB /* MultiNestedInPrivateNestedClass.swift in Sources */,
 				0C2B108704AEB93556C4B0CE /* StubNoReturnFunctionTest.swift in Sources */,
 				A983C68015E99296880C1E09 /* StubNoReturnThrowingFunctionTest.swift in Sources */,
 				6D280577520C906C474727EC /* StubThrowingFunctionTest.swift in Sources */,
@@ -2731,6 +2770,7 @@
 				B4CABEBF620374BC06D2823B /* TestUtils.swift in Sources */,
 				1B425DF3B416C5E4FA04532C /* ArgumentCaptorTest.swift in Sources */,
 				CADD146D25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift in Sources */,
+				CADD14DD25159143008C5EBB /* MultiNestedInNestedClass.swift in Sources */,
 				F713219CB9579070209F289B /* VerificationTest.swift in Sources */,
 				CACDD7692515249E00980F58 /* NestedExtensionClassTest.swift in Sources */,
 			);

--- a/Cuckoo.xcodeproj/project.pbxproj
+++ b/Cuckoo.xcodeproj/project.pbxproj
@@ -370,6 +370,18 @@
 		C918EF1A82AE3300CFD0178C /* Cuckoo-BridgingHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = A78767AF78A5705F914CB5F1 /* Cuckoo-BridgingHeader.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		C98DD2231948D6D9486E3C1C /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55014A1A85497F2153371D7 /* TestUtils.swift */; };
 		CA88A2D7512A9EE0D64D6879 /* StubbingProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A9BEFC601EF66DF42D5022 /* StubbingProxy.swift */; };
+		CACDD70625151C7F00980F58 /* NestedClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACDD70525151C7F00980F58 /* NestedClassTest.swift */; };
+		CACDD70725151C7F00980F58 /* NestedClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACDD70525151C7F00980F58 /* NestedClassTest.swift */; };
+		CACDD70825151C7F00980F58 /* NestedClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACDD70525151C7F00980F58 /* NestedClassTest.swift */; };
+		CACDD73B2515245B00980F58 /* NestedInNestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACDD73A2515245B00980F58 /* NestedInNestedClass.swift */; };
+		CACDD73C2515245B00980F58 /* NestedInNestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACDD73A2515245B00980F58 /* NestedInNestedClass.swift */; };
+		CACDD73D2515245B00980F58 /* NestedInNestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACDD73A2515245B00980F58 /* NestedInNestedClass.swift */; };
+		CACDD7572515247100980F58 /* NestedInExtensionFromClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACDD7562515247100980F58 /* NestedInExtensionFromClass.swift */; };
+		CACDD7582515247100980F58 /* NestedInExtensionFromClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACDD7562515247100980F58 /* NestedInExtensionFromClass.swift */; };
+		CACDD7592515247100980F58 /* NestedInExtensionFromClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACDD7562515247100980F58 /* NestedInExtensionFromClass.swift */; };
+		CACDD7672515249E00980F58 /* NestedExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */; };
+		CACDD7682515249E00980F58 /* NestedExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */; };
+		CACDD7692515249E00980F58 /* NestedExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */; };
 		CBB7017EE143A38098AD7287 /* GenericMethodClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B965102D09D6B0E94CDA8EA /* GenericMethodClassTest.swift */; };
 		CC2BA5A130CB61216E489D99 /* VerifyProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753FC6D19235B2C8F2DBAA7B /* VerifyProperty.swift */; };
 		CC60D01D5BD4771A8EC08F6A /* CreateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44692276AAFF9261EDD5D75 /* CreateMock.swift */; };
@@ -837,6 +849,10 @@
 		C8B9AF0995CE5604A511A17E /* OCMock.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCMock.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/OCMock.framework; sourceTree = DEVELOPER_DIR; };
 		C8D7931D2C7E8A64861A1863 /* OCMockObject+Workaround.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "OCMockObject+Workaround.m"; sourceTree = "<group>"; };
 		C9525C20EA498D59BFCE3F7B /* ObjectiveAssertThrows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveAssertThrows.swift; sourceTree = "<group>"; };
+		CACDD70525151C7F00980F58 /* NestedClassTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NestedClassTest.swift; sourceTree = "<group>"; };
+		CACDD73A2515245B00980F58 /* NestedInNestedClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedInNestedClass.swift; sourceTree = "<group>"; };
+		CACDD7562515247100980F58 /* NestedInExtensionFromClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedInExtensionFromClass.swift; sourceTree = "<group>"; };
+		CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedExtensionClassTest.swift; sourceTree = "<group>"; };
 		CB65661C2188A3E830EEBF72 /* ThreadLocal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadLocal.swift; sourceTree = "<group>"; };
 		CEBE505B4B98BE6289678CD1 /* MatchableTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchableTest.swift; sourceTree = "<group>"; };
 		D09B97C65DA87366B8605109 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
@@ -1164,6 +1180,8 @@
 				B5D26E97250A3A8B9AA4CB23 /* Source */,
 				47EF4290E156765F0A05913E /* Stubbing */,
 				48CB4CA852B87D8D86C18DA5 /* Verification */,
+				CACDD70525151C7F00980F58 /* NestedClassTest.swift */,
+				CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */,
 				6873C8013002AFEA7565BDAC /* ClassTest.swift */,
 				8CDB969240E4E2B12FF93284 /* CollisionClasses.swift */,
 				0BEF42DC82FC0EF50E83E6CA /* CuckooFunctionsTest.swift */,
@@ -1239,6 +1257,8 @@
 		B5D26E97250A3A8B9AA4CB23 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				CACDD73A2515245B00980F58 /* NestedInNestedClass.swift */,
+				CACDD7562515247100980F58 /* NestedInExtensionFromClass.swift */,
 				55DE1954C1D6E94F2911830A /* ClassForStubTesting.swift */,
 				32A299482E4D2B7B774373A1 /* ClassWithOptionals.swift */,
 				FB36E482FF288D775B744A02 /* ExcludedTestClass.swift */,
@@ -2305,6 +2325,7 @@
 				7C739BDCFE5EEC051A505646 /* ExcludedStubTest.swift in Sources */,
 				C40DE5DDD7A6B6566E11EC1E /* FailTest.swift in Sources */,
 				78D27D2AD38E87B228AF0556 /* GenericClassTest.swift in Sources */,
+				CACDD70725151C7F00980F58 /* NestedClassTest.swift in Sources */,
 				653C6B1B0884C6D58E624D2E /* GenericMethodClassTest.swift in Sources */,
 				9EAF1E992E94374BEC7E991F /* GenericProtocolTest.swift in Sources */,
 				15464C72B2E02BE3B83BF860 /* Array+matchersTest.swift in Sources */,
@@ -2313,10 +2334,12 @@
 				B35A528C2DA3EDD27AF9ED6D /* Dictionary+matchersTest.swift in Sources */,
 				F4D5A2D8B531EE28E22D5F1F /* MatchableTest.swift in Sources */,
 				8A7127D0E93C3654495D6150 /* ParameterMatcherFunctionsTest.swift in Sources */,
+				CACDD73C2515245B00980F58 /* NestedInNestedClass.swift in Sources */,
 				A98B094AF56BE63E7E4D2164 /* ParameterMatcherTest.swift in Sources */,
 				85BB583C1F89B50DC88999F2 /* ProtocolTest.swift in Sources */,
 				BC428931E53499C0EFDC802F /* ClassForStubTesting.swift in Sources */,
 				27BCAB9824D4747E00EAAB55 /* GeneratedMocks.swift in Sources */,
+				CACDD7582515247100980F58 /* NestedInExtensionFromClass.swift in Sources */,
 				39B67C20D2A61BF2376634F3 /* ClassWithOptionals.swift in Sources */,
 				4A91D2B262ED9EC2EAC65D85 /* ExcludedTestClass.swift in Sources */,
 				BA6739666F5DDC4ADA564E2C /* GenericClass.swift in Sources */,
@@ -2337,6 +2360,7 @@
 				C98DD2231948D6D9486E3C1C /* TestUtils.swift in Sources */,
 				83A5A8205205BF4D44F93CD0 /* ArgumentCaptorTest.swift in Sources */,
 				F191F17A741759B8031CB6D5 /* VerificationTest.swift in Sources */,
+				CACDD7682515249E00980F58 /* NestedExtensionClassTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2474,6 +2498,7 @@
 				114CF61041FB579920C5B7E0 /* ExcludedStubTest.swift in Sources */,
 				95D2EF56DE4359E935DA8881 /* FailTest.swift in Sources */,
 				B89DC8BEF25D0A07FC7AB353 /* GenericClassTest.swift in Sources */,
+				CACDD70625151C7F00980F58 /* NestedClassTest.swift in Sources */,
 				6185ED8EF7CDC1EB4A859B6B /* GenericMethodClassTest.swift in Sources */,
 				B814D550E3464500F775C91A /* GenericProtocolTest.swift in Sources */,
 				9B43D00AE620FC13BC6CDD3B /* Array+matchersTest.swift in Sources */,
@@ -2482,10 +2507,12 @@
 				322F32E04F570CD3C8DB85DB /* Dictionary+matchersTest.swift in Sources */,
 				34465E38954BFF6E973AFBC4 /* MatchableTest.swift in Sources */,
 				89D45ECD764B0F6DC9E8A934 /* ParameterMatcherFunctionsTest.swift in Sources */,
+				CACDD73B2515245B00980F58 /* NestedInNestedClass.swift in Sources */,
 				7DEB7E694AD63B5C7B9B22E6 /* ParameterMatcherTest.swift in Sources */,
 				E22E749D0A0B44EC528CB38F /* ProtocolTest.swift in Sources */,
 				2D2631FF3DFEB17188A08073 /* ClassForStubTesting.swift in Sources */,
 				68472F9A24D3ECA700E096C6 /* GeneratedMocks.swift in Sources */,
+				CACDD7572515247100980F58 /* NestedInExtensionFromClass.swift in Sources */,
 				F52EE531052666CFB50523E6 /* ClassWithOptionals.swift in Sources */,
 				8AEC76DECB68343825159FB1 /* ExcludedTestClass.swift in Sources */,
 				5EE0A57E2B90191B395C84E8 /* GenericClass.swift in Sources */,
@@ -2506,6 +2533,7 @@
 				AB4D73B2AF7C45B055A0909E /* TestUtils.swift in Sources */,
 				6D9C4E09B9E0AC6BD5AED4DA /* ArgumentCaptorTest.swift in Sources */,
 				E28273B64BC1C3C73331A168 /* VerificationTest.swift in Sources */,
+				CACDD7672515249E00980F58 /* NestedExtensionClassTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2629,6 +2657,7 @@
 				2728634862DD41A1F558CE7F /* ExcludedStubTest.swift in Sources */,
 				64725C719F048F677075C20E /* FailTest.swift in Sources */,
 				4570B0F63086A0AF7C682CE9 /* GenericClassTest.swift in Sources */,
+				CACDD70825151C7F00980F58 /* NestedClassTest.swift in Sources */,
 				CBB7017EE143A38098AD7287 /* GenericMethodClassTest.swift in Sources */,
 				84E115FC5DA7BC43B2751E6E /* GenericProtocolTest.swift in Sources */,
 				E43CC1CA72418C35F7FC5262 /* Array+matchersTest.swift in Sources */,
@@ -2637,10 +2666,12 @@
 				E39A67FBC1DD4826E4E22ECB /* Dictionary+matchersTest.swift in Sources */,
 				DD0595709253A1058AAD17D7 /* MatchableTest.swift in Sources */,
 				B2A0F9714DD9CCCDED6C0974 /* ParameterMatcherFunctionsTest.swift in Sources */,
+				CACDD73D2515245B00980F58 /* NestedInNestedClass.swift in Sources */,
 				453EA0CE5ABEA62595596C6F /* ParameterMatcherTest.swift in Sources */,
 				63E990EB0DEE6A4873F30538 /* ProtocolTest.swift in Sources */,
 				A977B902CD0127BCD5BD272F /* ClassForStubTesting.swift in Sources */,
 				27BCABAF24D474CD00EAAB55 /* GeneratedMocks.swift in Sources */,
+				CACDD7592515247100980F58 /* NestedInExtensionFromClass.swift in Sources */,
 				F09C7E5B6AD4AEB0166F871F /* ClassWithOptionals.swift in Sources */,
 				8B704B099E1FEA7F97ECEAE0 /* ExcludedTestClass.swift in Sources */,
 				68666AF31756DE755BED16A0 /* GenericClass.swift in Sources */,
@@ -2661,6 +2692,7 @@
 				B4CABEBF620374BC06D2823B /* TestUtils.swift in Sources */,
 				1B425DF3B416C5E4FA04532C /* ArgumentCaptorTest.swift in Sources */,
 				F713219CB9579070209F289B /* VerificationTest.swift in Sources */,
+				CACDD7692515249E00980F58 /* NestedExtensionClassTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Cuckoo.xcodeproj/project.pbxproj
+++ b/Cuckoo.xcodeproj/project.pbxproj
@@ -382,6 +382,9 @@
 		CACDD7672515249E00980F58 /* NestedExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */; };
 		CACDD7682515249E00980F58 /* NestedExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */; };
 		CACDD7692515249E00980F58 /* NestedExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */; };
+		CADD144525157A23008C5EBB /* NestedSubclassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD144425157A23008C5EBB /* NestedSubclassTests.swift */; };
+		CADD144625157A23008C5EBB /* NestedSubclassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD144425157A23008C5EBB /* NestedSubclassTests.swift */; };
+		CADD144725157A23008C5EBB /* NestedSubclassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD144425157A23008C5EBB /* NestedSubclassTests.swift */; };
 		CBB7017EE143A38098AD7287 /* GenericMethodClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B965102D09D6B0E94CDA8EA /* GenericMethodClassTest.swift */; };
 		CC2BA5A130CB61216E489D99 /* VerifyProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753FC6D19235B2C8F2DBAA7B /* VerifyProperty.swift */; };
 		CC60D01D5BD4771A8EC08F6A /* CreateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44692276AAFF9261EDD5D75 /* CreateMock.swift */; };
@@ -853,6 +856,7 @@
 		CACDD73A2515245B00980F58 /* NestedInNestedClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedInNestedClass.swift; sourceTree = "<group>"; };
 		CACDD7562515247100980F58 /* NestedInExtensionFromClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedInExtensionFromClass.swift; sourceTree = "<group>"; };
 		CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedExtensionClassTest.swift; sourceTree = "<group>"; };
+		CADD144425157A23008C5EBB /* NestedSubclassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedSubclassTests.swift; sourceTree = "<group>"; };
 		CB65661C2188A3E830EEBF72 /* ThreadLocal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadLocal.swift; sourceTree = "<group>"; };
 		CEBE505B4B98BE6289678CD1 /* MatchableTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchableTest.swift; sourceTree = "<group>"; };
 		D09B97C65DA87366B8605109 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
@@ -1181,6 +1185,7 @@
 				47EF4290E156765F0A05913E /* Stubbing */,
 				48CB4CA852B87D8D86C18DA5 /* Verification */,
 				CACDD70525151C7F00980F58 /* NestedClassTest.swift */,
+				CADD144425157A23008C5EBB /* NestedSubclassTests.swift */,
 				CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */,
 				6873C8013002AFEA7565BDAC /* ClassTest.swift */,
 				8CDB969240E4E2B12FF93284 /* CollisionClasses.swift */,
@@ -2328,6 +2333,7 @@
 				CACDD70725151C7F00980F58 /* NestedClassTest.swift in Sources */,
 				653C6B1B0884C6D58E624D2E /* GenericMethodClassTest.swift in Sources */,
 				9EAF1E992E94374BEC7E991F /* GenericProtocolTest.swift in Sources */,
+				CADD144625157A23008C5EBB /* NestedSubclassTests.swift in Sources */,
 				15464C72B2E02BE3B83BF860 /* Array+matchersTest.swift in Sources */,
 				AB3A869091F2C1705FCC5645 /* CallMatcherFunctionsTest.swift in Sources */,
 				890656235A725D4007EC7E6B /* CallMatcherTest.swift in Sources */,
@@ -2501,6 +2507,7 @@
 				CACDD70625151C7F00980F58 /* NestedClassTest.swift in Sources */,
 				6185ED8EF7CDC1EB4A859B6B /* GenericMethodClassTest.swift in Sources */,
 				B814D550E3464500F775C91A /* GenericProtocolTest.swift in Sources */,
+				CADD144525157A23008C5EBB /* NestedSubclassTests.swift in Sources */,
 				9B43D00AE620FC13BC6CDD3B /* Array+matchersTest.swift in Sources */,
 				6BAE868EB51D85115719DA33 /* CallMatcherFunctionsTest.swift in Sources */,
 				620292525840DE035421240A /* CallMatcherTest.swift in Sources */,
@@ -2660,6 +2667,7 @@
 				CACDD70825151C7F00980F58 /* NestedClassTest.swift in Sources */,
 				CBB7017EE143A38098AD7287 /* GenericMethodClassTest.swift in Sources */,
 				84E115FC5DA7BC43B2751E6E /* GenericProtocolTest.swift in Sources */,
+				CADD144725157A23008C5EBB /* NestedSubclassTests.swift in Sources */,
 				E43CC1CA72418C35F7FC5262 /* Array+matchersTest.swift in Sources */,
 				4C5633619E1E58D34CFEDF2A /* CallMatcherFunctionsTest.swift in Sources */,
 				F01B6FF9BCFEED923AFCE5FC /* CallMatcherTest.swift in Sources */,

--- a/Cuckoo.xcodeproj/project.pbxproj
+++ b/Cuckoo.xcodeproj/project.pbxproj
@@ -418,6 +418,15 @@
 		CADD153B2515A858008C5EBB /* MultiNestedExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD153A2515A858008C5EBB /* MultiNestedExtensionClassTest.swift */; };
 		CADD153C2515A858008C5EBB /* MultiNestedExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD153A2515A858008C5EBB /* MultiNestedExtensionClassTest.swift */; };
 		CADD153D2515A858008C5EBB /* MultiNestedExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD153A2515A858008C5EBB /* MultiNestedExtensionClassTest.swift */; };
+		CADD154B2515A9CB008C5EBB /* NestedInNestedStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD154A2515A9CB008C5EBB /* NestedInNestedStruct.swift */; };
+		CADD154C2515A9CB008C5EBB /* NestedInNestedStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD154A2515A9CB008C5EBB /* NestedInNestedStruct.swift */; };
+		CADD154D2515A9CB008C5EBB /* NestedInNestedStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD154A2515A9CB008C5EBB /* NestedInNestedStruct.swift */; };
+		CADD155B2515AA34008C5EBB /* NestedStructTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD155A2515AA34008C5EBB /* NestedStructTest.swift */; };
+		CADD155C2515AA34008C5EBB /* NestedStructTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD155A2515AA34008C5EBB /* NestedStructTest.swift */; };
+		CADD155D2515AA34008C5EBB /* NestedStructTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD155A2515AA34008C5EBB /* NestedStructTest.swift */; };
+		CADD156B2515AA83008C5EBB /* NestedStructExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD156A2515AA83008C5EBB /* NestedStructExtensionClassTest.swift */; };
+		CADD156C2515AA83008C5EBB /* NestedStructExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD156A2515AA83008C5EBB /* NestedStructExtensionClassTest.swift */; };
+		CADD156D2515AA83008C5EBB /* NestedStructExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD156A2515AA83008C5EBB /* NestedStructExtensionClassTest.swift */; };
 		CBB7017EE143A38098AD7287 /* GenericMethodClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B965102D09D6B0E94CDA8EA /* GenericMethodClassTest.swift */; };
 		CC2BA5A130CB61216E489D99 /* VerifyProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753FC6D19235B2C8F2DBAA7B /* VerifyProperty.swift */; };
 		CC60D01D5BD4771A8EC08F6A /* CreateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44692276AAFF9261EDD5D75 /* CreateMock.swift */; };
@@ -901,6 +910,9 @@
 		CADD151A2515937D008C5EBB /* MultiNestedClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiNestedClassTest.swift; sourceTree = "<group>"; };
 		CADD152A2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiLayeredNestedTestedSubclassTest.swift; sourceTree = "<group>"; };
 		CADD153A2515A858008C5EBB /* MultiNestedExtensionClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiNestedExtensionClassTest.swift; sourceTree = "<group>"; };
+		CADD154A2515A9CB008C5EBB /* NestedInNestedStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedInNestedStruct.swift; sourceTree = "<group>"; };
+		CADD155A2515AA34008C5EBB /* NestedStructTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedStructTest.swift; sourceTree = "<group>"; };
+		CADD156A2515AA83008C5EBB /* NestedStructExtensionClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedStructExtensionClassTest.swift; sourceTree = "<group>"; };
 		CB65661C2188A3E830EEBF72 /* ThreadLocal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadLocal.swift; sourceTree = "<group>"; };
 		CEBE505B4B98BE6289678CD1 /* MatchableTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchableTest.swift; sourceTree = "<group>"; };
 		D09B97C65DA87366B8605109 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
@@ -1229,8 +1241,10 @@
 				47EF4290E156765F0A05913E /* Stubbing */,
 				48CB4CA852B87D8D86C18DA5 /* Verification */,
 				CACDD70525151C7F00980F58 /* NestedClassTest.swift */,
+				CADD155A2515AA34008C5EBB /* NestedStructTest.swift */,
 				CADD144425157A23008C5EBB /* NestedSubclassTests.swift */,
 				CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */,
+				CADD156A2515AA83008C5EBB /* NestedStructExtensionClassTest.swift */,
 				CADD146A25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift */,
 				CADD147A25158A44008C5EBB /* NestedPrivateClassTest.swift */,
 				CADD151A2515937D008C5EBB /* MultiNestedClassTest.swift */,
@@ -1312,6 +1326,7 @@
 			isa = PBXGroup;
 			children = (
 				CACDD73A2515245B00980F58 /* NestedInNestedClass.swift */,
+				CADD154A2515A9CB008C5EBB /* NestedInNestedStruct.swift */,
 				CADD148A25158A62008C5EBB /* NestedPrivateExtensionClass.swift */,
 				CADD149A25158B60008C5EBB /* NestedInPrivateNestedClass.swift */,
 				CACDD7562515247100980F58 /* NestedInExtensionFromClass.swift */,
@@ -2386,6 +2401,7 @@
 				CADD149C25158B60008C5EBB /* NestedInPrivateNestedClass.swift in Sources */,
 				5290A06644BA9B7046E81643 /* CuckooFunctionsTest.swift in Sources */,
 				928FE5CCF9DEBC62FACF4C46 /* DefaultValueRegistryTest.swift in Sources */,
+				CADD156C2515AA83008C5EBB /* NestedStructExtensionClassTest.swift in Sources */,
 				7C739BDCFE5EEC051A505646 /* ExcludedStubTest.swift in Sources */,
 				C40DE5DDD7A6B6566E11EC1E /* FailTest.swift in Sources */,
 				78D27D2AD38E87B228AF0556 /* GenericClassTest.swift in Sources */,
@@ -2394,6 +2410,7 @@
 				9EAF1E992E94374BEC7E991F /* GenericProtocolTest.swift in Sources */,
 				CADD144625157A23008C5EBB /* NestedSubclassTests.swift in Sources */,
 				15464C72B2E02BE3B83BF860 /* Array+matchersTest.swift in Sources */,
+				CADD155C2515AA34008C5EBB /* NestedStructTest.swift in Sources */,
 				AB3A869091F2C1705FCC5645 /* CallMatcherFunctionsTest.swift in Sources */,
 				890656235A725D4007EC7E6B /* CallMatcherTest.swift in Sources */,
 				B35A528C2DA3EDD27AF9ED6D /* Dictionary+matchersTest.swift in Sources */,
@@ -2404,6 +2421,7 @@
 				85BB583C1F89B50DC88999F2 /* ProtocolTest.swift in Sources */,
 				BC428931E53499C0EFDC802F /* ClassForStubTesting.swift in Sources */,
 				CADD152C2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift in Sources */,
+				CADD154C2515A9CB008C5EBB /* NestedInNestedStruct.swift in Sources */,
 				CADD148C25158A62008C5EBB /* NestedPrivateExtensionClass.swift in Sources */,
 				27BCAB9824D4747E00EAAB55 /* GeneratedMocks.swift in Sources */,
 				CACDD7582515247100980F58 /* NestedInExtensionFromClass.swift in Sources */,
@@ -2571,6 +2589,7 @@
 				CADD149B25158B60008C5EBB /* NestedInPrivateNestedClass.swift in Sources */,
 				F25919FEF1D3A359CA975AAE /* CuckooFunctionsTest.swift in Sources */,
 				F22196061D37E66590633818 /* DefaultValueRegistryTest.swift in Sources */,
+				CADD156B2515AA83008C5EBB /* NestedStructExtensionClassTest.swift in Sources */,
 				114CF61041FB579920C5B7E0 /* ExcludedStubTest.swift in Sources */,
 				95D2EF56DE4359E935DA8881 /* FailTest.swift in Sources */,
 				B89DC8BEF25D0A07FC7AB353 /* GenericClassTest.swift in Sources */,
@@ -2579,6 +2598,7 @@
 				B814D550E3464500F775C91A /* GenericProtocolTest.swift in Sources */,
 				CADD144525157A23008C5EBB /* NestedSubclassTests.swift in Sources */,
 				9B43D00AE620FC13BC6CDD3B /* Array+matchersTest.swift in Sources */,
+				CADD155B2515AA34008C5EBB /* NestedStructTest.swift in Sources */,
 				6BAE868EB51D85115719DA33 /* CallMatcherFunctionsTest.swift in Sources */,
 				620292525840DE035421240A /* CallMatcherTest.swift in Sources */,
 				322F32E04F570CD3C8DB85DB /* Dictionary+matchersTest.swift in Sources */,
@@ -2589,6 +2609,7 @@
 				E22E749D0A0B44EC528CB38F /* ProtocolTest.swift in Sources */,
 				2D2631FF3DFEB17188A08073 /* ClassForStubTesting.swift in Sources */,
 				CADD152B2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift in Sources */,
+				CADD154B2515A9CB008C5EBB /* NestedInNestedStruct.swift in Sources */,
 				CADD148B25158A62008C5EBB /* NestedPrivateExtensionClass.swift in Sources */,
 				68472F9A24D3ECA700E096C6 /* GeneratedMocks.swift in Sources */,
 				CACDD7572515247100980F58 /* NestedInExtensionFromClass.swift in Sources */,
@@ -2742,6 +2763,7 @@
 				CADD149D25158B60008C5EBB /* NestedInPrivateNestedClass.swift in Sources */,
 				1DB1CBFA2D7B012C81B1312B /* CuckooFunctionsTest.swift in Sources */,
 				2E54AB548933FF3D2F7E1384 /* DefaultValueRegistryTest.swift in Sources */,
+				CADD156D2515AA83008C5EBB /* NestedStructExtensionClassTest.swift in Sources */,
 				2728634862DD41A1F558CE7F /* ExcludedStubTest.swift in Sources */,
 				64725C719F048F677075C20E /* FailTest.swift in Sources */,
 				4570B0F63086A0AF7C682CE9 /* GenericClassTest.swift in Sources */,
@@ -2750,6 +2772,7 @@
 				84E115FC5DA7BC43B2751E6E /* GenericProtocolTest.swift in Sources */,
 				CADD144725157A23008C5EBB /* NestedSubclassTests.swift in Sources */,
 				E43CC1CA72418C35F7FC5262 /* Array+matchersTest.swift in Sources */,
+				CADD155D2515AA34008C5EBB /* NestedStructTest.swift in Sources */,
 				4C5633619E1E58D34CFEDF2A /* CallMatcherFunctionsTest.swift in Sources */,
 				F01B6FF9BCFEED923AFCE5FC /* CallMatcherTest.swift in Sources */,
 				E39A67FBC1DD4826E4E22ECB /* Dictionary+matchersTest.swift in Sources */,
@@ -2760,6 +2783,7 @@
 				63E990EB0DEE6A4873F30538 /* ProtocolTest.swift in Sources */,
 				A977B902CD0127BCD5BD272F /* ClassForStubTesting.swift in Sources */,
 				CADD152D2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift in Sources */,
+				CADD154D2515A9CB008C5EBB /* NestedInNestedStruct.swift in Sources */,
 				CADD148D25158A62008C5EBB /* NestedPrivateExtensionClass.swift in Sources */,
 				27BCABAF24D474CD00EAAB55 /* GeneratedMocks.swift in Sources */,
 				CACDD7592515247100980F58 /* NestedInExtensionFromClass.swift in Sources */,

--- a/Cuckoo.xcodeproj/project.pbxproj
+++ b/Cuckoo.xcodeproj/project.pbxproj
@@ -385,6 +385,18 @@
 		CADD144525157A23008C5EBB /* NestedSubclassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD144425157A23008C5EBB /* NestedSubclassTests.swift */; };
 		CADD144625157A23008C5EBB /* NestedSubclassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD144425157A23008C5EBB /* NestedSubclassTests.swift */; };
 		CADD144725157A23008C5EBB /* NestedSubclassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD144425157A23008C5EBB /* NestedSubclassTests.swift */; };
+		CADD146B25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD146A25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift */; };
+		CADD146C25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD146A25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift */; };
+		CADD146D25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD146A25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift */; };
+		CADD147B25158A44008C5EBB /* NestedPrivateClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD147A25158A44008C5EBB /* NestedPrivateClassTest.swift */; };
+		CADD147C25158A44008C5EBB /* NestedPrivateClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD147A25158A44008C5EBB /* NestedPrivateClassTest.swift */; };
+		CADD147D25158A44008C5EBB /* NestedPrivateClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD147A25158A44008C5EBB /* NestedPrivateClassTest.swift */; };
+		CADD148B25158A62008C5EBB /* NestedPrivateExtensionClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD148A25158A62008C5EBB /* NestedPrivateExtensionClass.swift */; };
+		CADD148C25158A62008C5EBB /* NestedPrivateExtensionClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD148A25158A62008C5EBB /* NestedPrivateExtensionClass.swift */; };
+		CADD148D25158A62008C5EBB /* NestedPrivateExtensionClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD148A25158A62008C5EBB /* NestedPrivateExtensionClass.swift */; };
+		CADD149B25158B60008C5EBB /* NestedInPrivateNestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD149A25158B60008C5EBB /* NestedInPrivateNestedClass.swift */; };
+		CADD149C25158B60008C5EBB /* NestedInPrivateNestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD149A25158B60008C5EBB /* NestedInPrivateNestedClass.swift */; };
+		CADD149D25158B60008C5EBB /* NestedInPrivateNestedClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD149A25158B60008C5EBB /* NestedInPrivateNestedClass.swift */; };
 		CBB7017EE143A38098AD7287 /* GenericMethodClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B965102D09D6B0E94CDA8EA /* GenericMethodClassTest.swift */; };
 		CC2BA5A130CB61216E489D99 /* VerifyProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753FC6D19235B2C8F2DBAA7B /* VerifyProperty.swift */; };
 		CC60D01D5BD4771A8EC08F6A /* CreateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44692276AAFF9261EDD5D75 /* CreateMock.swift */; };
@@ -857,6 +869,10 @@
 		CACDD7562515247100980F58 /* NestedInExtensionFromClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedInExtensionFromClass.swift; sourceTree = "<group>"; };
 		CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedExtensionClassTest.swift; sourceTree = "<group>"; };
 		CADD144425157A23008C5EBB /* NestedSubclassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedSubclassTests.swift; sourceTree = "<group>"; };
+		CADD146A25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedPrivateExtensionClassTest.swift; sourceTree = "<group>"; };
+		CADD147A25158A44008C5EBB /* NestedPrivateClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedPrivateClassTest.swift; sourceTree = "<group>"; };
+		CADD148A25158A62008C5EBB /* NestedPrivateExtensionClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedPrivateExtensionClass.swift; sourceTree = "<group>"; };
+		CADD149A25158B60008C5EBB /* NestedInPrivateNestedClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NestedInPrivateNestedClass.swift; sourceTree = "<group>"; };
 		CB65661C2188A3E830EEBF72 /* ThreadLocal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadLocal.swift; sourceTree = "<group>"; };
 		CEBE505B4B98BE6289678CD1 /* MatchableTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchableTest.swift; sourceTree = "<group>"; };
 		D09B97C65DA87366B8605109 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
@@ -1187,6 +1203,8 @@
 				CACDD70525151C7F00980F58 /* NestedClassTest.swift */,
 				CADD144425157A23008C5EBB /* NestedSubclassTests.swift */,
 				CACDD7662515249E00980F58 /* NestedExtensionClassTest.swift */,
+				CADD146A25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift */,
+				CADD147A25158A44008C5EBB /* NestedPrivateClassTest.swift */,
 				6873C8013002AFEA7565BDAC /* ClassTest.swift */,
 				8CDB969240E4E2B12FF93284 /* CollisionClasses.swift */,
 				0BEF42DC82FC0EF50E83E6CA /* CuckooFunctionsTest.swift */,
@@ -1263,6 +1281,8 @@
 			isa = PBXGroup;
 			children = (
 				CACDD73A2515245B00980F58 /* NestedInNestedClass.swift */,
+				CADD148A25158A62008C5EBB /* NestedPrivateExtensionClass.swift */,
+				CADD149A25158B60008C5EBB /* NestedInPrivateNestedClass.swift */,
 				CACDD7562515247100980F58 /* NestedInExtensionFromClass.swift */,
 				55DE1954C1D6E94F2911830A /* ClassForStubTesting.swift */,
 				32A299482E4D2B7B774373A1 /* ClassWithOptionals.swift */,
@@ -2322,9 +2342,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CADD147C25158A44008C5EBB /* NestedPrivateClassTest.swift in Sources */,
 				E8CE88DD377BB4EE8233AAFB /* TestError.swift in Sources */,
 				4F490D8457B9919E2E6A05B0 /* ClassTest.swift in Sources */,
 				BBA5EEAD87D96D3B15C78757 /* CollisionClasses.swift in Sources */,
+				CADD149C25158B60008C5EBB /* NestedInPrivateNestedClass.swift in Sources */,
 				5290A06644BA9B7046E81643 /* CuckooFunctionsTest.swift in Sources */,
 				928FE5CCF9DEBC62FACF4C46 /* DefaultValueRegistryTest.swift in Sources */,
 				7C739BDCFE5EEC051A505646 /* ExcludedStubTest.swift in Sources */,
@@ -2344,6 +2366,7 @@
 				A98B094AF56BE63E7E4D2164 /* ParameterMatcherTest.swift in Sources */,
 				85BB583C1F89B50DC88999F2 /* ProtocolTest.swift in Sources */,
 				BC428931E53499C0EFDC802F /* ClassForStubTesting.swift in Sources */,
+				CADD148C25158A62008C5EBB /* NestedPrivateExtensionClass.swift in Sources */,
 				27BCAB9824D4747E00EAAB55 /* GeneratedMocks.swift in Sources */,
 				CACDD7582515247100980F58 /* NestedInExtensionFromClass.swift in Sources */,
 				39B67C20D2A61BF2376634F3 /* ClassWithOptionals.swift in Sources */,
@@ -2365,6 +2388,7 @@
 				9F315C759A53B4765706C631 /* StubbingTest.swift in Sources */,
 				C98DD2231948D6D9486E3C1C /* TestUtils.swift in Sources */,
 				83A5A8205205BF4D44F93CD0 /* ArgumentCaptorTest.swift in Sources */,
+				CADD146C25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift in Sources */,
 				F191F17A741759B8031CB6D5 /* VerificationTest.swift in Sources */,
 				CACDD7682515249E00980F58 /* NestedExtensionClassTest.swift in Sources */,
 			);
@@ -2496,9 +2520,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CADD147B25158A44008C5EBB /* NestedPrivateClassTest.swift in Sources */,
 				827A670BF9391A7C01822AF1 /* TestError.swift in Sources */,
 				EAFA72896871E0A2629AC784 /* ClassTest.swift in Sources */,
 				E2D62D3393599003755F59F6 /* CollisionClasses.swift in Sources */,
+				CADD149B25158B60008C5EBB /* NestedInPrivateNestedClass.swift in Sources */,
 				F25919FEF1D3A359CA975AAE /* CuckooFunctionsTest.swift in Sources */,
 				F22196061D37E66590633818 /* DefaultValueRegistryTest.swift in Sources */,
 				114CF61041FB579920C5B7E0 /* ExcludedStubTest.swift in Sources */,
@@ -2518,6 +2544,7 @@
 				7DEB7E694AD63B5C7B9B22E6 /* ParameterMatcherTest.swift in Sources */,
 				E22E749D0A0B44EC528CB38F /* ProtocolTest.swift in Sources */,
 				2D2631FF3DFEB17188A08073 /* ClassForStubTesting.swift in Sources */,
+				CADD148B25158A62008C5EBB /* NestedPrivateExtensionClass.swift in Sources */,
 				68472F9A24D3ECA700E096C6 /* GeneratedMocks.swift in Sources */,
 				CACDD7572515247100980F58 /* NestedInExtensionFromClass.swift in Sources */,
 				F52EE531052666CFB50523E6 /* ClassWithOptionals.swift in Sources */,
@@ -2539,6 +2566,7 @@
 				061991F996D7C014B67647A9 /* StubbingTest.swift in Sources */,
 				AB4D73B2AF7C45B055A0909E /* TestUtils.swift in Sources */,
 				6D9C4E09B9E0AC6BD5AED4DA /* ArgumentCaptorTest.swift in Sources */,
+				CADD146B25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift in Sources */,
 				E28273B64BC1C3C73331A168 /* VerificationTest.swift in Sources */,
 				CACDD7672515249E00980F58 /* NestedExtensionClassTest.swift in Sources */,
 			);
@@ -2656,9 +2684,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CADD147D25158A44008C5EBB /* NestedPrivateClassTest.swift in Sources */,
 				116D8FBB03787C2D7F7C99CC /* TestError.swift in Sources */,
 				D477FC12C92D54376DA507B5 /* ClassTest.swift in Sources */,
 				023F8564E2E6BDC0C3740D15 /* CollisionClasses.swift in Sources */,
+				CADD149D25158B60008C5EBB /* NestedInPrivateNestedClass.swift in Sources */,
 				1DB1CBFA2D7B012C81B1312B /* CuckooFunctionsTest.swift in Sources */,
 				2E54AB548933FF3D2F7E1384 /* DefaultValueRegistryTest.swift in Sources */,
 				2728634862DD41A1F558CE7F /* ExcludedStubTest.swift in Sources */,
@@ -2678,6 +2708,7 @@
 				453EA0CE5ABEA62595596C6F /* ParameterMatcherTest.swift in Sources */,
 				63E990EB0DEE6A4873F30538 /* ProtocolTest.swift in Sources */,
 				A977B902CD0127BCD5BD272F /* ClassForStubTesting.swift in Sources */,
+				CADD148D25158A62008C5EBB /* NestedPrivateExtensionClass.swift in Sources */,
 				27BCABAF24D474CD00EAAB55 /* GeneratedMocks.swift in Sources */,
 				CACDD7592515247100980F58 /* NestedInExtensionFromClass.swift in Sources */,
 				F09C7E5B6AD4AEB0166F871F /* ClassWithOptionals.swift in Sources */,
@@ -2699,6 +2730,7 @@
 				03393CDA9320B79B75A2DE1D /* StubbingTest.swift in Sources */,
 				B4CABEBF620374BC06D2823B /* TestUtils.swift in Sources */,
 				1B425DF3B416C5E4FA04532C /* ArgumentCaptorTest.swift in Sources */,
+				CADD146D25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift in Sources */,
 				F713219CB9579070209F289B /* VerificationTest.swift in Sources */,
 				CACDD7692515249E00980F58 /* NestedExtensionClassTest.swift in Sources */,
 			);

--- a/Cuckoo.xcodeproj/project.pbxproj
+++ b/Cuckoo.xcodeproj/project.pbxproj
@@ -412,6 +412,12 @@
 		CADD151B2515937D008C5EBB /* MultiNestedClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD151A2515937D008C5EBB /* MultiNestedClassTest.swift */; };
 		CADD151C2515937D008C5EBB /* MultiNestedClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD151A2515937D008C5EBB /* MultiNestedClassTest.swift */; };
 		CADD151D2515937D008C5EBB /* MultiNestedClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD151A2515937D008C5EBB /* MultiNestedClassTest.swift */; };
+		CADD152B2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD152A2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift */; };
+		CADD152C2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD152A2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift */; };
+		CADD152D2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD152A2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift */; };
+		CADD153B2515A858008C5EBB /* MultiNestedExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD153A2515A858008C5EBB /* MultiNestedExtensionClassTest.swift */; };
+		CADD153C2515A858008C5EBB /* MultiNestedExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD153A2515A858008C5EBB /* MultiNestedExtensionClassTest.swift */; };
+		CADD153D2515A858008C5EBB /* MultiNestedExtensionClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADD153A2515A858008C5EBB /* MultiNestedExtensionClassTest.swift */; };
 		CBB7017EE143A38098AD7287 /* GenericMethodClassTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B965102D09D6B0E94CDA8EA /* GenericMethodClassTest.swift */; };
 		CC2BA5A130CB61216E489D99 /* VerifyProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753FC6D19235B2C8F2DBAA7B /* VerifyProperty.swift */; };
 		CC60D01D5BD4771A8EC08F6A /* CreateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44692276AAFF9261EDD5D75 /* CreateMock.swift */; };
@@ -893,6 +899,8 @@
 		CADD14FA2515918B008C5EBB /* MultiNestedInPrivateNestedClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiNestedInPrivateNestedClass.swift; sourceTree = "<group>"; };
 		CADD150A251591D8008C5EBB /* MultiNestedInExtensionFromClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiNestedInExtensionFromClass.swift; sourceTree = "<group>"; };
 		CADD151A2515937D008C5EBB /* MultiNestedClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiNestedClassTest.swift; sourceTree = "<group>"; };
+		CADD152A2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiLayeredNestedTestedSubclassTest.swift; sourceTree = "<group>"; };
+		CADD153A2515A858008C5EBB /* MultiNestedExtensionClassTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiNestedExtensionClassTest.swift; sourceTree = "<group>"; };
 		CB65661C2188A3E830EEBF72 /* ThreadLocal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadLocal.swift; sourceTree = "<group>"; };
 		CEBE505B4B98BE6289678CD1 /* MatchableTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchableTest.swift; sourceTree = "<group>"; };
 		D09B97C65DA87366B8605109 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
@@ -1226,6 +1234,8 @@
 				CADD146A25158A34008C5EBB /* NestedPrivateExtensionClassTest.swift */,
 				CADD147A25158A44008C5EBB /* NestedPrivateClassTest.swift */,
 				CADD151A2515937D008C5EBB /* MultiNestedClassTest.swift */,
+				CADD152A2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift */,
+				CADD153A2515A858008C5EBB /* MultiNestedExtensionClassTest.swift */,
 				6873C8013002AFEA7565BDAC /* ClassTest.swift */,
 				8CDB969240E4E2B12FF93284 /* CollisionClasses.swift */,
 				0BEF42DC82FC0EF50E83E6CA /* CuckooFunctionsTest.swift */,
@@ -2393,6 +2403,7 @@
 				A98B094AF56BE63E7E4D2164 /* ParameterMatcherTest.swift in Sources */,
 				85BB583C1F89B50DC88999F2 /* ProtocolTest.swift in Sources */,
 				BC428931E53499C0EFDC802F /* ClassForStubTesting.swift in Sources */,
+				CADD152C2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift in Sources */,
 				CADD148C25158A62008C5EBB /* NestedPrivateExtensionClass.swift in Sources */,
 				27BCAB9824D4747E00EAAB55 /* GeneratedMocks.swift in Sources */,
 				CACDD7582515247100980F58 /* NestedInExtensionFromClass.swift in Sources */,
@@ -2405,6 +2416,7 @@
 				976C2EBAEC277E931B3AB769 /* ObjcProtocol.swift in Sources */,
 				39E8C61BBB09A4A27B1350AE /* TestedClass.swift in Sources */,
 				890B1518BDDFBE8FDFDCFA26 /* TestedProtocol.swift in Sources */,
+				CADD153C2515A858008C5EBB /* MultiNestedExtensionClassTest.swift in Sources */,
 				3F51FDF6C83FA2474D59710D /* TestedSubProtocol.swift in Sources */,
 				939F8351018A269238F58553 /* TestedSubclass.swift in Sources */,
 				DAD4C161978D36BCC64AB3C6 /* UnicodeTestProtocol.swift in Sources */,
@@ -2576,6 +2588,7 @@
 				7DEB7E694AD63B5C7B9B22E6 /* ParameterMatcherTest.swift in Sources */,
 				E22E749D0A0B44EC528CB38F /* ProtocolTest.swift in Sources */,
 				2D2631FF3DFEB17188A08073 /* ClassForStubTesting.swift in Sources */,
+				CADD152B2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift in Sources */,
 				CADD148B25158A62008C5EBB /* NestedPrivateExtensionClass.swift in Sources */,
 				68472F9A24D3ECA700E096C6 /* GeneratedMocks.swift in Sources */,
 				CACDD7572515247100980F58 /* NestedInExtensionFromClass.swift in Sources */,
@@ -2588,6 +2601,7 @@
 				7E628E0FB6B59C6B641AF6B1 /* ObjcProtocol.swift in Sources */,
 				944E8A4093693E48B3ACD938 /* TestedClass.swift in Sources */,
 				41F4150D95BC01E3AD5BC2B3 /* TestedProtocol.swift in Sources */,
+				CADD153B2515A858008C5EBB /* MultiNestedExtensionClassTest.swift in Sources */,
 				18A918338118AE7B7FDDDD8E /* TestedSubProtocol.swift in Sources */,
 				0405F62A3C80516B8B556DEE /* TestedSubclass.swift in Sources */,
 				0ED1CB69A10271E8108F20FE /* UnicodeTestProtocol.swift in Sources */,
@@ -2745,6 +2759,7 @@
 				453EA0CE5ABEA62595596C6F /* ParameterMatcherTest.swift in Sources */,
 				63E990EB0DEE6A4873F30538 /* ProtocolTest.swift in Sources */,
 				A977B902CD0127BCD5BD272F /* ClassForStubTesting.swift in Sources */,
+				CADD152D2515A69E008C5EBB /* MultiLayeredNestedTestedSubclassTest.swift in Sources */,
 				CADD148D25158A62008C5EBB /* NestedPrivateExtensionClass.swift in Sources */,
 				27BCABAF24D474CD00EAAB55 /* GeneratedMocks.swift in Sources */,
 				CACDD7592515247100980F58 /* NestedInExtensionFromClass.swift in Sources */,
@@ -2757,6 +2772,7 @@
 				610B9F6B3C52E7241A80FC27 /* ObjcProtocol.swift in Sources */,
 				3FA36E79C29711257E3AD899 /* TestedClass.swift in Sources */,
 				05CCD0B58CBF8AD378D407B1 /* TestedProtocol.swift in Sources */,
+				CADD153D2515A858008C5EBB /* MultiNestedExtensionClassTest.swift in Sources */,
 				86838C17C151FFE82DC5B616 /* TestedSubProtocol.swift in Sources */,
 				71325312F391F1ED64037ABB /* TestedSubclass.swift in Sources */,
 				9B54EA8552637FBD7476E0A7 /* UnicodeTestProtocol.swift in Sources */,

--- a/Generator/Source/CuckooGeneratorFramework/Generator.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Generator.swift
@@ -61,7 +61,12 @@ public struct Generator {
         fputs("DECLARATIONS IN MOCK: \(declarations)\n", stdout)
 
         let containers = declarations.compactMap { $0 as? ContainerToken }
-            .filter { $0.accessibility.isAccessible }.map { $0.serializeWithType() }
+            .filter {
+                if let parent = $0.topMostParent {
+                    return parent.accessibility.isAccessible && $0.accessibility.isAccessible
+                }
+                return $0.accessibility.isAccessible
+            }.map { $0.serializeWithType() }
 
         fputs("CONTAINERS IN MOCK: \(containers.map { $0["name"] })\n", stdout)
     

--- a/Generator/Source/CuckooGeneratorFramework/Generator.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Generator.swift
@@ -62,8 +62,8 @@ public struct Generator {
 
         let containers = declarations.compactMap { $0 as? ContainerToken }
             .filter {
-                if let parent = $0.topMostParent {
-                    return parent.accessibility.isAccessible && $0.accessibility.isAccessible
+                if let parent = $0.parent {
+                    return parent.allHierarchiesAreAccessible && $0.accessibility.isAccessible
                 }
                 return $0.accessibility.isAccessible
             }.map { $0.serializeWithType() }

--- a/Generator/Source/CuckooGeneratorFramework/Generator.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Generator.swift
@@ -58,7 +58,6 @@ public struct Generator {
         }
 
         let environment = Environment(extensions: [ext])
-        fputs("DECLARATIONS IN MOCK: \(declarations)\n", stdout)
 
         let containers = declarations.compactMap { $0 as? ContainerToken }
             .filter {
@@ -68,7 +67,6 @@ public struct Generator {
                 return $0.accessibility.isAccessible
             }.map { $0.serializeWithType() }
 
-        fputs("CONTAINERS IN MOCK: \(containers.map { $0["name"] })\n", stdout)
     
         return try environment.renderTemplate(string: Templates.mock, context: ["containers": containers, "debug": debug])
     }

--- a/Generator/Source/CuckooGeneratorFramework/Generator.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Generator.swift
@@ -59,22 +59,9 @@ public struct Generator {
 
         let environment = Environment(extensions: [ext])
         fputs("DECLARATIONS IN MOCK: \(declarations)\n", stdout)
-        
-        let accessibleDeclarations = declarations.compactMap { $0 as? ContainerToken }
-            .filter { $0.accessibility.isAccessible }
 
-        let nestedContainers = accessibleDeclarations
-            .filter { $0.accessibility.isAccessible && $0.children.contains { $0 is ContainerToken } }
-            .map { (parent: $0, container:$0.children.compactMap { $0 as? ContainerToken }) }
-            .flatMap { (parent, children) in
-                children.map { child -> [String: Any] in
-                    var c = child
-                    c.parent = parent
-                    return c.serializeWithType()
-                }
-            }
-
-        let containers = nestedContainers + accessibleDeclarations.map { $0.serializeWithType() }
+        let containers = declarations.compactMap { $0 as? ContainerToken }
+            .filter { $0.accessibility.isAccessible }.map { $0.serializeWithType() }
 
         fputs("CONTAINERS IN MOCK: \(containers.map { $0["name"] })\n", stdout)
     

--- a/Generator/Source/CuckooGeneratorFramework/Reference.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Reference.swift
@@ -2,7 +2,7 @@
 //  Reference.swift
 //  CuckooGeneratorFramework
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Generator/Source/CuckooGeneratorFramework/Reference.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Reference.swift
@@ -1,0 +1,26 @@
+//
+//  Reference.swift
+//  CuckooGeneratorFramework
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+
+@dynamicMemberLookup
+public final class Reference<Value> {
+    private(set) var value: Value
+    
+    public init(value: Value) {
+        self.value = value
+    }
+    
+    public subscript<T>(dynamicMember keyPath: KeyPath<Value, T>) -> T {
+        value[keyPath: keyPath]
+    }
+    
+    public subscript<T>(dynamicMember keyPath: WritableKeyPath<Value, T>) -> T {
+        get { value[keyPath: keyPath] }
+        set { value[keyPath: keyPath] = newValue }
+    }
+}

--- a/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
@@ -15,6 +15,10 @@ extension Templates {
 {% for attribute in container.attributes %}
 {{ attribute.text }}
 {% endfor %}
+    {% if container.hasParent %}
+extension {{ container.parent }} {
+    {% endif %}
+
 {{ container.accessibility }} class {{ container.mockName }}{{ container.genericParameters }}: {{ container.name }}{% if container.isImplementation %}{{ container.genericArguments }}{% endif %}, {% if container.isImplementation %}Cuckoo.ClassMock{% else %}Cuckoo.ProtocolMock{% endif %} {
     {% if container.isGeneric and not container.isImplementation %}
     {{ container.accessibility }} typealias MocksType = \(typeErasureClassName){{ container.genericArguments }}
@@ -124,6 +128,10 @@ extension Templates {
 }
 
 \(Templates.noImplStub)
+
+    {% if container.hasParent %}
+}
+    {% endif %}
 
 {% endfor %}
 """

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -26,6 +26,20 @@ public struct Tokenizer {
             let structure = try Structure(file: file)
 
             let declarations = tokenize(structure.dictionary[Key.Substructure.rawValue] as? [SourceKitRepresentable] ?? [])
+                .flatMap { declaration -> [Token] in
+                    fputs("Declaration token: \(declaration).\n", stdout)
+                    guard let parent = declaration as? ContainerToken else { return [declaration] }
+                    fputs("PARENT token: \(parent).\n", stdout)
+                    return [parent] + parent.children.compactMap { child -> Token? in
+                        guard var c = child as? ContainerToken else { return nil }
+                        c.parent = Reference(value: parent)
+                        fputs("CHILD token: \(c).\n", stdout)
+                        return c
+                    }
+                }
+
+            fputs("ALL DECLARATION tokens: \(declarations).\n", stdout)
+
             let imports = tokenize(imports: declarations)
 
             return FileRepresentation(sourceFile: file, declarations: declarations + imports)

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -28,7 +28,6 @@ public struct Tokenizer {
             let declarations = tokenize(structure.dictionary[Key.Substructure.rawValue] as? [SourceKitRepresentable] ?? [])
                 .flatMap { declaration -> [Token] in
                     guard let parent = declaration as? ParentToken else { return [declaration] }
-//                    fputs("PARENT token: \(parent).\n", stdout)
                     return [parent] + parent.adoptAllYoungerGenerations()
                 }
 
@@ -89,7 +88,7 @@ public struct Tokenizer {
             }
             return nil
         }
-
+        
         let accessibility = (dictionary[Key.Accessibility.rawValue] as? String).flatMap { Accessibility(rawValue: $0) } ?? .Internal
         let type: WrappableType?
         if let stringType = dictionary[Key.TypeName.rawValue] as? String {
@@ -148,6 +147,17 @@ public struct Tokenizer {
                 attributes: attributes,
                 genericParameters: fixedGenericParameters)
 
+        case Kinds.StructDeclaration.rawValue:
+            let subtokens = tokenize(dictionary[Key.Substructure.rawValue] as? [SourceKitRepresentable] ?? [])
+            let children = subtokens.noneOf(Initializer.self)
+
+            return StructDeclaration(name: name,
+                                     accessibility: accessibility,
+                                     range: range!,
+                                     nameRange: nameRange!,
+                                     bodyRange: bodyRange!,
+                                     children: children)
+            
         case Kinds.ExtensionDeclaration.rawValue:
             let subtokens = tokenize(dictionary[Key.Substructure.rawValue] as? [SourceKitRepresentable] ?? [])
             let children = subtokens.noneOf(Initializer.self)

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -149,7 +149,7 @@ public struct Tokenizer {
 
         case Kinds.StructDeclaration.rawValue:
             let subtokens = tokenize(dictionary[Key.Substructure.rawValue] as? [SourceKitRepresentable] ?? [])
-            let children = subtokens.noneOf(Initializer.self)
+            let children = subtokens.only(ContainerToken.self)
 
             return StructDeclaration(name: name,
                                      accessibility: accessibility,
@@ -160,7 +160,7 @@ public struct Tokenizer {
             
         case Kinds.ExtensionDeclaration.rawValue:
             let subtokens = tokenize(dictionary[Key.Substructure.rawValue] as? [SourceKitRepresentable] ?? [])
-            let children = subtokens.noneOf(Initializer.self)
+            let children = subtokens.only(ContainerToken.self)
 
             return ExtensionDeclaration(name: name,
                                         accessibility: accessibility,

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -27,9 +27,9 @@ public struct Tokenizer {
 
             let declarations = tokenize(structure.dictionary[Key.Substructure.rawValue] as? [SourceKitRepresentable] ?? [])
                 .flatMap { declaration -> [Token] in
-                    fputs("Declaration token: \(declaration).\n", stdout)
-                    guard let parent = declaration as? ContainerToken else { return [declaration] }
-                    fputs("PARENT token: \(parent).\n", stdout)
+//                    fputs("Declaration token: \(declaration).\n", stdout)
+                    guard let parent = declaration as? ParentToken else { return [declaration] }
+//                    fputs("PARENT token: \(parent).\n", stdout)
                     return [parent] + parent.children.compactMap { child -> Token? in
                         guard var c = child as? ContainerToken else { return nil }
                         c.parent = Reference(value: parent)
@@ -38,7 +38,7 @@ public struct Tokenizer {
                     }
                 }
 
-            fputs("ALL DECLARATION tokens: \(declarations).\n", stdout)
+//            fputs("ALL DECLARATION tokens: \(declarations).\n", stdout)
 
             let imports = tokenize(imports: declarations)
 
@@ -157,7 +157,15 @@ public struct Tokenizer {
                 genericParameters: fixedGenericParameters)
 
         case Kinds.ExtensionDeclaration.rawValue:
-            return ExtensionDeclaration(range: range!)
+            let subtokens = tokenize(dictionary[Key.Substructure.rawValue] as? [SourceKitRepresentable] ?? [])
+            let children = subtokens.noneOf(Initializer.self)
+
+            return ExtensionDeclaration(name: name,
+                                        accessibility: accessibility,
+                                        range: range!,
+                                        nameRange: nameRange!,
+                                        bodyRange: bodyRange!,
+                                        children: children)
 
         case Kinds.InstanceVariable.rawValue:
             let setterAccessibility = (dictionary[Key.SetterAccessibility.rawValue] as? String).flatMap(Accessibility.init)

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -27,18 +27,10 @@ public struct Tokenizer {
 
             let declarations = tokenize(structure.dictionary[Key.Substructure.rawValue] as? [SourceKitRepresentable] ?? [])
                 .flatMap { declaration -> [Token] in
-//                    fputs("Declaration token: \(declaration).\n", stdout)
                     guard let parent = declaration as? ParentToken else { return [declaration] }
 //                    fputs("PARENT token: \(parent).\n", stdout)
-                    return [parent] + parent.children.compactMap { child -> Token? in
-                        guard var c = child as? ContainerToken else { return nil }
-                        c.parent = Reference(value: parent)
-                        fputs("CHILD token: \(c).\n", stdout)
-                        return c
-                    }
+                    return [parent] + parent.adoptAllYoungerGenerations()
                 }
-
-//            fputs("ALL DECLARATION tokens: \(declarations).\n", stdout)
 
             let imports = tokenize(imports: declarations)
 

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ChildToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ChildToken.swift
@@ -2,7 +2,7 @@
 //  ChildToken.swift
 //  CuckooGeneratorFramework
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ChildToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ChildToken.swift
@@ -10,13 +10,3 @@ import Foundation
 public protocol ChildToken: Token {
     var parent: Reference<ParentToken>? { get set }
 }
-
-extension ChildToken {
-    var topMostParent:ParentToken? {
-        var currentParent = parent?.value
-        while let grandParent = (currentParent as? ChildToken)?.parent?.value {
-            currentParent = grandParent
-        }
-        return currentParent
-    }
-}

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ChildToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ChildToken.swift
@@ -1,0 +1,22 @@
+//
+//  ChildToken.swift
+//  CuckooGeneratorFramework
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+
+public protocol ChildToken: Token {
+    var parent: Reference<ParentToken>? { get set }
+}
+
+extension ChildToken {
+    var topMostParent:ParentToken? {
+        var currentParent = parent?.value
+        while let grandParent = (currentParent as? ChildToken)?.parent?.value {
+            currentParent = grandParent
+        }
+        return currentParent
+    }
+}

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
@@ -9,7 +9,7 @@
 public struct ClassDeclaration: ContainerToken, HasAccessibility {
     public let implementation: Bool = true
     public var name: String
-    public var parent: ContainerToken? = nil
+    public var parent: Reference<ContainerToken>? = nil
     public var accessibility: Accessibility
     public var range: CountableRange<Int>
     public var nameRange: CountableRange<Int>
@@ -26,6 +26,7 @@ public struct ClassDeclaration: ContainerToken, HasAccessibility {
     public func replace(children tokens: [Token]) -> ClassDeclaration {
         return ClassDeclaration(
             name: self.name,
+            parent: self.parent,
             accessibility: self.accessibility,
             range: self.range,
             nameRange: self.nameRange,

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
@@ -9,6 +9,7 @@
 public struct ClassDeclaration: ContainerToken, HasAccessibility {
     public let implementation: Bool = true
     public var name: String
+    public var parent: ContainerToken? = nil
     public var accessibility: Accessibility
     public var range: CountableRange<Int>
     public var nameRange: CountableRange<Int>

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ClassDeclaration.swift
@@ -9,7 +9,7 @@
 public struct ClassDeclaration: ContainerToken, HasAccessibility {
     public let implementation: Bool = true
     public var name: String
-    public var parent: Reference<ContainerToken>? = nil
+    public var parent: Reference<ParentToken>? = nil
     public var accessibility: Accessibility
     public var range: CountableRange<Int>
     public var nameRange: CountableRange<Int>

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
@@ -8,7 +8,7 @@
 
 public protocol ContainerToken: Token, HasAccessibility {
     var name: String { get }
-    var parent: ContainerToken? { get set }
+    var parent: Reference<ContainerToken>? { get set }
     var range: CountableRange<Int> { get }
     var nameRange: CountableRange<Int> { get }
     var bodyRange: CountableRange<Int> { get }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
@@ -51,7 +51,7 @@ extension ContainerToken {
             "accessibility": accessibility.sourceName,
             "isAccessible": accessibility.isAccessible,
             "hasParent": parent != nil,
-            "parent": parent?.name ?? "",
+            "parent": parent?.fullyQualifiedName ?? "",
             "children": accessibilityAdjustedChildren.map { $0.serializeWithType() },
             "properties": properties,
             "methods": methods,

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
@@ -6,14 +6,17 @@
 //  Copyright © 2016 Brightify. All rights reserved.
 //
 
-public protocol ContainerToken: Token, HasAccessibility {
+public protocol ParentToken: Token, HasAccessibility {
     var name: String { get }
-    var parent: Reference<ContainerToken>? { get set }
     var range: CountableRange<Int> { get }
     var nameRange: CountableRange<Int> { get }
     var bodyRange: CountableRange<Int> { get }
-    var initializers: [Initializer] { get }
     var children: [Token] { get }
+}
+
+public protocol ContainerToken: ParentToken {
+    var parent: Reference<ParentToken>? { get set }
+    var initializers: [Initializer] { get }
     var implementation: Bool { get }
     var inheritedTypes: [InheritanceDeclaration] { get }
     var attributes: [Attribute] { get }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
@@ -8,6 +8,7 @@
 
 public protocol ContainerToken: Token, HasAccessibility {
     var name: String { get }
+    var parent: ContainerToken? { get set }
     var range: CountableRange<Int> { get }
     var nameRange: CountableRange<Int> { get }
     var bodyRange: CountableRange<Int> { get }
@@ -55,6 +56,8 @@ extension ContainerToken {
             "name": name,
             "accessibility": accessibility.sourceName,
             "isAccessible": accessibility.isAccessible,
+            "hasParent": parent != nil,
+            "parent": parent?.name ?? "",
             "children": accessibilityAdjustedChildren.map { $0.serializeWithType() },
             "properties": properties,
             "methods": methods,

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
@@ -6,16 +6,7 @@
 //  Copyright © 2016 Brightify. All rights reserved.
 //
 
-public protocol ParentToken: Token, HasAccessibility {
-    var name: String { get }
-    var range: CountableRange<Int> { get }
-    var nameRange: CountableRange<Int> { get }
-    var bodyRange: CountableRange<Int> { get }
-    var children: [Token] { get }
-}
-
-public protocol ContainerToken: ParentToken {
-    var parent: Reference<ParentToken>? { get set }
+public protocol ContainerToken: ParentToken, ChildToken {
     var initializers: [Initializer] { get }
     var implementation: Bool { get }
     var inheritedTypes: [InheritanceDeclaration] { get }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ExtensionDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ExtensionDeclaration.swift
@@ -6,10 +6,15 @@
 //  Copyright © 2016 Brightify. All rights reserved.
 //
 
-public struct ExtensionDeclaration: Token {
+public struct ExtensionDeclaration: ParentToken {
     // TODO Implement support for extensions
+    public let name: String
+    public var accessibility: Accessibility
     public let range: CountableRange<Int>
-
+    public let nameRange: CountableRange<Int>
+    public let bodyRange: CountableRange<Int>
+    public let children: [Token]
+    
     public func isEqual(to other: Token) -> Bool {
         guard let other = other as? ExtensionDeclaration else { return false }
         return self.range == other.range

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Kinds.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Kinds.swift
@@ -11,6 +11,7 @@ public enum Kinds: String {
     case InstanceMethod = "source.lang.swift.decl.function.method.instance"
     case MethodParameter = "source.lang.swift.decl.var.parameter"
     case ClassDeclaration = "source.lang.swift.decl.class"
+    case StructDeclaration = "source.lang.swift.decl.struct"
     case ExtensionDeclaration = "source.lang.swift.decl.extension"
     case InstanceVariable = "source.lang.swift.decl.var.instance"
     case GenericParameter = "source.lang.swift.decl.generic_type_param"

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ParentToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ParentToken.swift
@@ -1,0 +1,16 @@
+//
+//  ParentToken.swift
+//  CuckooGeneratorFramework
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+
+public protocol ParentToken: Token, HasAccessibility {
+    var name: String { get }
+    var range: CountableRange<Int> { get }
+    var nameRange: CountableRange<Int> { get }
+    var bodyRange: CountableRange<Int> { get }
+    var children: [Token] { get }
+}

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ParentToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ParentToken.swift
@@ -2,7 +2,7 @@
 //  ParentToken.swift
 //  CuckooGeneratorFramework
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ParentToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ParentToken.swift
@@ -42,7 +42,6 @@ extension ParentToken {
             .compactMap { child -> ParentToken? in
                 guard var c = child as? ContainerToken else { return nil }
                 c.parent = Reference(value: self)
-                fputs("CHILD token: \(c).\n", stdout)
                 return c
             }
             .flatMap { [$0] + $0.adoptAllYoungerGenerations() }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ParentToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ParentToken.swift
@@ -14,3 +14,27 @@ public protocol ParentToken: Token, HasAccessibility {
     var bodyRange: CountableRange<Int> { get }
     var children: [Token] { get }
 }
+
+extension ParentToken {
+    
+    var fullyQualifiedName:String {
+        var names = [name]
+        var parent:ParentToken? = (self as? ChildToken)?.parent?.value
+        while let p = parent {
+            names.insert(p.name, at: 0)
+            parent = (p as? ChildToken)?.parent?.value
+        }
+        return names.joined(separator: ".")
+    }
+    
+    func adoptAllYoungerGenerations() -> [ParentToken] {
+        return children
+            .compactMap { child -> ParentToken? in
+                guard var c = child as? ContainerToken else { return nil }
+                c.parent = Reference(value: self)
+                fputs("CHILD token: \(c).\n", stdout)
+                return c
+            }
+            .flatMap { [$0] + $0.adoptAllYoungerGenerations() }
+    }
+}

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ParentToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ParentToken.swift
@@ -27,6 +27,16 @@ extension ParentToken {
         return names.joined(separator: ".")
     }
     
+    var allHierarchiesAreAccessible:Bool {
+        guard accessibility.isAccessible else { return false }
+        var parent:ParentToken? = (self as? ChildToken)?.parent?.value
+        while let p = parent {
+            guard p.accessibility.isAccessible else { return false }
+            parent = (p as? ChildToken)?.parent?.value
+        }
+        return true
+    }
+    
     func adoptAllYoungerGenerations() -> [ParentToken] {
         return children
             .compactMap { child -> ParentToken? in

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
@@ -9,7 +9,7 @@
 public struct ProtocolDeclaration: ContainerToken, HasAccessibility {
     public let implementation: Bool = false
     public var name: String
-    public var parent: Reference<ContainerToken>? = nil
+    public var parent: Reference<ParentToken>? = nil
     public var accessibility: Accessibility
     public var range: CountableRange<Int>
     public var nameRange: CountableRange<Int>

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
@@ -9,7 +9,7 @@
 public struct ProtocolDeclaration: ContainerToken, HasAccessibility {
     public let implementation: Bool = false
     public var name: String
-    public var parent: ContainerToken? = nil
+    public var parent: Reference<ContainerToken>? = nil
     public var accessibility: Accessibility
     public var range: CountableRange<Int>
     public var nameRange: CountableRange<Int>
@@ -23,6 +23,7 @@ public struct ProtocolDeclaration: ContainerToken, HasAccessibility {
     public func replace(children tokens: [Token]) -> ProtocolDeclaration {
         return ProtocolDeclaration(
             name: self.name,
+            parent: self.parent,
             accessibility: self.accessibility,
             range: self.range,
             nameRange: self.nameRange,

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
@@ -9,6 +9,7 @@
 public struct ProtocolDeclaration: ContainerToken, HasAccessibility {
     public let implementation: Bool = false
     public var name: String
+    public var parent: ContainerToken? = nil
     public var accessibility: Accessibility
     public var range: CountableRange<Int>
     public var nameRange: CountableRange<Int>

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/StructDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/StructDeclaration.swift
@@ -1,0 +1,23 @@
+//
+//  StructDeclaration.swift
+//  CuckooGeneratorFramework
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+
+public struct StructDeclaration: ParentToken {
+    // NOTE: Purely for supporting nested classes, could be any generic parent (like extensions)
+    public let name: String
+    public var accessibility: Accessibility
+    public let range: CountableRange<Int>
+    public let nameRange: CountableRange<Int>
+    public let bodyRange: CountableRange<Int>
+    public let children: [Token]
+    
+    public func isEqual(to other: Token) -> Bool {
+        guard let other = other as? ExtensionDeclaration else { return false }
+        return self.range == other.range
+    }
+}

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/StructDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/StructDeclaration.swift
@@ -2,7 +2,7 @@
 //  StructDeclaration.swift
 //  CuckooGeneratorFramework
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,7 +5,7 @@ DEPENDENCIES:
   - OCMock
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs:
     - OCMock
 
 SPEC CHECKSUMS:
@@ -13,4 +13,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 60c654375f1e6dacd28d3d807f69d3618e7a619e
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.9.3

--- a/Tests/Swift/MultiLayeredNestedTestedSubclassTest.swift
+++ b/Tests/Swift/MultiLayeredNestedTestedSubclassTest.swift
@@ -1,0 +1,219 @@
+//
+//  MultiLayeredNestedTestedSubclassTest.swift
+//  Cuckoo
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+import XCTest
+import Cuckoo
+
+class MultiLayeredNestedTestedSubclassTest: XCTestCase {
+
+    private var mock: Multi.Layered.Nested.MockMultiLayeredNestedTestedSubclass!
+
+    override func setUp() {
+        super.setUp()
+
+        mock = Multi.Layered.Nested.MockMultiLayeredNestedTestedSubclass()
+    }
+
+    func testReadOnlyProperty() {
+        let mock = Multi.Layered.Nested.MockMultiLayeredNestedTestedSubclass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyProperty, "a")
+        verify(mock).readOnlyProperty.get()
+    }
+
+    func testReadOnlyOptionalProperty() {
+        let mock = Multi.Layered.Nested.MockMultiLayeredNestedTestedSubclass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyOptionalProperty, "a")
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testOptionalReadOnlyPropertyIsNil() {
+        let mock = Multi.Layered.Nested.MockMultiLayeredNestedTestedSubclass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn(nil)
+        }
+
+        XCTAssertNil(mock.readOnlyOptionalProperty)
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testReadWriteProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.readWriteProperty.get).thenReturn(1)
+            when(mock.readWriteProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.readWriteProperty = 0
+
+        XCTAssertEqual(mock.readWriteProperty, 1)
+        XCTAssertTrue(called)
+        verify(mock).readWriteProperty.get()
+        verify(mock).readWriteProperty.set(0)
+    }
+
+    func testOptionalProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.optionalProperty.get).thenReturn(nil)
+            when(mock.optionalProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.optionalProperty = 0
+
+        XCTAssertNil(mock.optionalProperty)
+        XCTAssertTrue(called)
+        verify(mock).optionalProperty.get()
+        verify(mock).optionalProperty.set(equal(to: 0))
+    }
+
+    func testNoReturn() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.noReturn()).then { _ in called = true }
+        }
+
+        mock.noReturn()
+
+        XCTAssertTrue(called)
+        verify(mock).noReturn()
+    }
+
+    func testCountCharacters() {
+        stub(mock) { mock in
+            when(mock.count(characters: "a")).thenReturn(1)
+        }
+
+        XCTAssertEqual(mock.count(characters: "a"), 1)
+        verify(mock).count(characters: "a")
+    }
+
+    func testWithThrows() {
+        stub(mock) { mock in
+            when(mock.withThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            _ = try mock.withThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withThrows()
+    }
+
+    func testWithNoReturnThrows() {
+        stub(mock) { mock in
+            when(mock.withNoReturnThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            try mock.withNoReturnThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withNoReturnThrows()
+    }
+
+    func testWithClosure() {
+        func anyNestedClosure<IN1, IN2, OUT>() -> ParameterMatcher<((IN1) -> IN2) -> OUT> {
+            return ParameterMatcher()
+        }
+
+        stub(mock) { mock in
+            when(mock.withClosure(anyClosure())).then { $0("a") }
+            when(mock.withClosureReturningVoid(anyClosure())).then { $0("a")() }
+            when(mock.withClosureReturningInt(anyClosure())).then { $0("a")(1) }
+            when(mock.withOptionalClosureAlone(anyClosure())).then { $0?("a")(1) ?? 1 }
+            when(mock.withNestedClosure1(anyClosure())).then { $0("a")({ Int($0) ?? 1 }) }
+            when(mock.withNestedClosure2(anyNestedClosure())).then { $0({ Int($0) ?? 1 })({ Int($0) ?? 1 }) }
+        }
+
+        XCTAssertEqual(mock.withClosure { _ in 1 }, 1)
+        XCTAssertEqual(mock.withClosureReturningVoid {_ in { return 1 } }, 1)
+        XCTAssertEqual(mock.withClosureReturningInt { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withOptionalClosureAlone { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure1 { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure2 { _ in { _ in return 1 } }, 1)
+
+        verify(mock).withClosure(anyClosure())
+        verify(mock).withClosureReturningVoid(anyClosure())
+        verify(mock).withClosureReturningInt(anyClosure())
+        verify(mock).withOptionalClosureAlone(anyClosure())
+        verify(mock).withNestedClosure1(anyClosure())
+        verify(mock).withNestedClosure2(anyNestedClosure())
+    }
+
+    func testWithEscape() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withEscape(anyString(), action: anyClosure())).then { text, closure in closure(text) }
+        }
+
+        mock.withEscape("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withEscape(anyString(), action: anyClosure())
+    }
+
+    func testWithOptionalClosure() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withOptionalClosure(anyString(), closure: anyClosure())).then { text, closure in closure?(text)  }
+        }
+
+        mock.withOptionalClosure("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withOptionalClosure(anyString(), closure: anyClosure())
+    }
+
+    func testWithLabel() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withLabelAndUnderscore(labelA: anyString(), anyString())).then { _ in called = true }
+        }
+
+        mock.withLabelAndUnderscore(labelA: "a", "b")
+        XCTAssertTrue(called)
+        verify(mock).withLabelAndUnderscore(labelA: anyString(), anyString())
+    }
+
+    func testCallingCountCharactersMethodWithHello() {
+        stub(mock) { mock in
+            when(mock.callingCountCharactersMethodWithHello()).thenCallRealImplementation()
+            when(mock.count(characters: any())).thenReturn(0)
+        }
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+        verify(mock).count(characters: "Hello")
+    }
+
+    func testDefaultImplCall() {
+        mock.enableDefaultImplementation(Multi.Layered.Nested.MultiLayeredNestedTestedSubclassStub())
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+    }
+}

--- a/Tests/Swift/MultiLayeredNestedTestedSubclassTest.swift
+++ b/Tests/Swift/MultiLayeredNestedTestedSubclassTest.swift
@@ -2,7 +2,7 @@
 //  MultiLayeredNestedTestedSubclassTest.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/MultiNestedClassTest.swift
+++ b/Tests/Swift/MultiNestedClassTest.swift
@@ -2,7 +2,7 @@
 //  MultiNestedClassTest.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/MultiNestedClassTest.swift
+++ b/Tests/Swift/MultiNestedClassTest.swift
@@ -1,0 +1,219 @@
+//
+//  MultiNestedClassTest.swift
+//  Cuckoo
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+import XCTest
+import Cuckoo
+
+class MultiNestedClassTest: XCTestCase {
+
+    private var mock: Multi.Nested.MockMultiNestedTestedSubclass!
+
+    override func setUp() {
+        super.setUp()
+
+        mock = Multi.Nested.MockMultiNestedTestedSubclass()
+    }
+
+    func testReadOnlyProperty() {
+        let mock = Multi.Nested.MockMultiNestedTestedSubclass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyProperty, "a")
+        verify(mock).readOnlyProperty.get()
+    }
+
+    func testReadOnlyOptionalProperty() {
+        let mock = Multi.Nested.MockMultiNestedTestedSubclass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyOptionalProperty, "a")
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testOptionalReadOnlyPropertyIsNil() {
+        let mock = Multi.Nested.MockMultiNestedTestedSubclass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn(nil)
+        }
+
+        XCTAssertNil(mock.readOnlyOptionalProperty)
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testReadWriteProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.readWriteProperty.get).thenReturn(1)
+            when(mock.readWriteProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.readWriteProperty = 0
+
+        XCTAssertEqual(mock.readWriteProperty, 1)
+        XCTAssertTrue(called)
+        verify(mock).readWriteProperty.get()
+        verify(mock).readWriteProperty.set(0)
+    }
+
+    func testOptionalProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.optionalProperty.get).thenReturn(nil)
+            when(mock.optionalProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.optionalProperty = 0
+
+        XCTAssertNil(mock.optionalProperty)
+        XCTAssertTrue(called)
+        verify(mock).optionalProperty.get()
+        verify(mock).optionalProperty.set(equal(to: 0))
+    }
+
+    func testNoReturn() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.noReturn()).then { _ in called = true }
+        }
+
+        mock.noReturn()
+
+        XCTAssertTrue(called)
+        verify(mock).noReturn()
+    }
+
+    func testCountCharacters() {
+        stub(mock) { mock in
+            when(mock.count(characters: "a")).thenReturn(1)
+        }
+
+        XCTAssertEqual(mock.count(characters: "a"), 1)
+        verify(mock).count(characters: "a")
+    }
+
+    func testWithThrows() {
+        stub(mock) { mock in
+            when(mock.withThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            _ = try mock.withThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withThrows()
+    }
+
+    func testWithNoReturnThrows() {
+        stub(mock) { mock in
+            when(mock.withNoReturnThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            try mock.withNoReturnThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withNoReturnThrows()
+    }
+
+    func testWithClosure() {
+        func anyNestedClosure<IN1, IN2, OUT>() -> ParameterMatcher<((IN1) -> IN2) -> OUT> {
+            return ParameterMatcher()
+        }
+
+        stub(mock) { mock in
+            when(mock.withClosure(anyClosure())).then { $0("a") }
+            when(mock.withClosureReturningVoid(anyClosure())).then { $0("a")() }
+            when(mock.withClosureReturningInt(anyClosure())).then { $0("a")(1) }
+            when(mock.withOptionalClosureAlone(anyClosure())).then { $0?("a")(1) ?? 1 }
+            when(mock.withNestedClosure1(anyClosure())).then { $0("a")({ Int($0) ?? 1 }) }
+            when(mock.withNestedClosure2(anyNestedClosure())).then { $0({ Int($0) ?? 1 })({ Int($0) ?? 1 }) }
+        }
+
+        XCTAssertEqual(mock.withClosure { _ in 1 }, 1)
+        XCTAssertEqual(mock.withClosureReturningVoid {_ in { return 1 } }, 1)
+        XCTAssertEqual(mock.withClosureReturningInt { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withOptionalClosureAlone { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure1 { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure2 { _ in { _ in return 1 } }, 1)
+
+        verify(mock).withClosure(anyClosure())
+        verify(mock).withClosureReturningVoid(anyClosure())
+        verify(mock).withClosureReturningInt(anyClosure())
+        verify(mock).withOptionalClosureAlone(anyClosure())
+        verify(mock).withNestedClosure1(anyClosure())
+        verify(mock).withNestedClosure2(anyNestedClosure())
+    }
+
+    func testWithEscape() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withEscape(anyString(), action: anyClosure())).then { text, closure in closure(text) }
+        }
+
+        mock.withEscape("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withEscape(anyString(), action: anyClosure())
+    }
+
+    func testWithOptionalClosure() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withOptionalClosure(anyString(), closure: anyClosure())).then { text, closure in closure?(text)  }
+        }
+
+        mock.withOptionalClosure("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withOptionalClosure(anyString(), closure: anyClosure())
+    }
+
+    func testWithLabel() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withLabelAndUnderscore(labelA: anyString(), anyString())).then { _ in called = true }
+        }
+
+        mock.withLabelAndUnderscore(labelA: "a", "b")
+        XCTAssertTrue(called)
+        verify(mock).withLabelAndUnderscore(labelA: anyString(), anyString())
+    }
+
+    func testCallingCountCharactersMethodWithHello() {
+        stub(mock) { mock in
+            when(mock.callingCountCharactersMethodWithHello()).thenCallRealImplementation()
+            when(mock.count(characters: any())).thenReturn(0)
+        }
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+        verify(mock).count(characters: "Hello")
+    }
+
+    func testDefaultImplCall() {
+        mock.enableDefaultImplementation(Multi.Nested.MultiNestedTestedSubclassStub())
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+    }
+}

--- a/Tests/Swift/MultiNestedExtensionClassTest.swift
+++ b/Tests/Swift/MultiNestedExtensionClassTest.swift
@@ -2,7 +2,7 @@
 //  MultiNestedExtensionClassTest.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/MultiNestedExtensionClassTest.swift
+++ b/Tests/Swift/MultiNestedExtensionClassTest.swift
@@ -1,0 +1,219 @@
+//
+//  MultiNestedExtensionClassTest.swift
+//  Cuckoo
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+import XCTest
+import Cuckoo
+
+class MultiNestedExtensionClassTests: XCTestCase {
+
+    private var mock: Multi.Nested.MockNestedExtensionTestedClass!
+
+    override func setUp() {
+        super.setUp()
+
+        mock = Multi.Nested.MockNestedExtensionTestedClass()
+    }
+
+    func testReadOnlyProperty() {
+        let mock = Multi.Nested.MockNestedExtensionTestedClass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyProperty, "a")
+        verify(mock).readOnlyProperty.get()
+    }
+
+    func testReadOnlyOptionalProperty() {
+        let mock = Multi.Nested.MockNestedExtensionTestedClass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyOptionalProperty, "a")
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testOptionalReadOnlyPropertyIsNil() {
+        let mock = Multi.Nested.MockNestedExtensionTestedClass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn(nil)
+        }
+
+        XCTAssertNil(mock.readOnlyOptionalProperty)
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testReadWriteProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.readWriteProperty.get).thenReturn(1)
+            when(mock.readWriteProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.readWriteProperty = 0
+
+        XCTAssertEqual(mock.readWriteProperty, 1)
+        XCTAssertTrue(called)
+        verify(mock).readWriteProperty.get()
+        verify(mock).readWriteProperty.set(0)
+    }
+
+    func testOptionalProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.optionalProperty.get).thenReturn(nil)
+            when(mock.optionalProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.optionalProperty = 0
+
+        XCTAssertNil(mock.optionalProperty)
+        XCTAssertTrue(called)
+        verify(mock).optionalProperty.get()
+        verify(mock).optionalProperty.set(equal(to: 0))
+    }
+
+    func testNoReturn() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.noReturn()).then { _ in called = true }
+        }
+
+        mock.noReturn()
+
+        XCTAssertTrue(called)
+        verify(mock).noReturn()
+    }
+
+    func testCountCharacters() {
+        stub(mock) { mock in
+            when(mock.count(characters: "a")).thenReturn(1)
+        }
+
+        XCTAssertEqual(mock.count(characters: "a"), 1)
+        verify(mock).count(characters: "a")
+    }
+
+    func testWithThrows() {
+        stub(mock) { mock in
+            when(mock.withThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            _ = try mock.withThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withThrows()
+    }
+
+    func testWithNoReturnThrows() {
+        stub(mock) { mock in
+            when(mock.withNoReturnThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            try mock.withNoReturnThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withNoReturnThrows()
+    }
+
+    func testWithClosure() {
+        func anyNestedClosure<IN1, IN2, OUT>() -> ParameterMatcher<((IN1) -> IN2) -> OUT> {
+            return ParameterMatcher()
+        }
+
+        stub(mock) { mock in
+            when(mock.withClosure(anyClosure())).then { $0("a") }
+            when(mock.withClosureReturningVoid(anyClosure())).then { $0("a")() }
+            when(mock.withClosureReturningInt(anyClosure())).then { $0("a")(1) }
+            when(mock.withOptionalClosureAlone(anyClosure())).then { $0?("a")(1) ?? 1 }
+            when(mock.withNestedClosure1(anyClosure())).then { $0("a")({ Int($0) ?? 1 }) }
+            when(mock.withNestedClosure2(anyNestedClosure())).then { $0({ Int($0) ?? 1 })({ Int($0) ?? 1 }) }
+        }
+
+        XCTAssertEqual(mock.withClosure { _ in 1 }, 1)
+        XCTAssertEqual(mock.withClosureReturningVoid {_ in { return 1 } }, 1)
+        XCTAssertEqual(mock.withClosureReturningInt { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withOptionalClosureAlone { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure1 { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure2 { _ in { _ in return 1 } }, 1)
+
+        verify(mock).withClosure(anyClosure())
+        verify(mock).withClosureReturningVoid(anyClosure())
+        verify(mock).withClosureReturningInt(anyClosure())
+        verify(mock).withOptionalClosureAlone(anyClosure())
+        verify(mock).withNestedClosure1(anyClosure())
+        verify(mock).withNestedClosure2(anyNestedClosure())
+    }
+
+    func testWithEscape() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withEscape(anyString(), action: anyClosure())).then { text, closure in closure(text) }
+        }
+
+        mock.withEscape("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withEscape(anyString(), action: anyClosure())
+    }
+
+    func testWithOptionalClosure() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withOptionalClosure(anyString(), closure: anyClosure())).then { text, closure in closure?(text)  }
+        }
+
+        mock.withOptionalClosure("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withOptionalClosure(anyString(), closure: anyClosure())
+    }
+
+    func testWithLabel() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withLabelAndUnderscore(labelA: anyString(), anyString())).then { _ in called = true }
+        }
+
+        mock.withLabelAndUnderscore(labelA: "a", "b")
+        XCTAssertTrue(called)
+        verify(mock).withLabelAndUnderscore(labelA: anyString(), anyString())
+    }
+
+    func testCallingCountCharactersMethodWithHello() {
+        stub(mock) { mock in
+            when(mock.callingCountCharactersMethodWithHello()).thenCallRealImplementation()
+            when(mock.count(characters: any())).thenReturn(0)
+        }
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+        verify(mock).count(characters: "Hello")
+    }
+
+    func testDefaultImplCall() {
+        mock.enableDefaultImplementation(Multi.Nested.NestedExtensionTestedClassStub())
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+    }
+}

--- a/Tests/Swift/NestedClassTest.swift
+++ b/Tests/Swift/NestedClassTest.swift
@@ -1,0 +1,233 @@
+//
+//  NestedClassTest.swift
+//  Cuckoo
+//
+//  Created by thompsty on 9/17/20.
+//
+
+import XCTest
+import Cuckoo
+
+extension Nested.NestedTestedClass: Mocked {
+    typealias MockType = Nested.MockNestedTestedClass
+}
+
+class NestedClassTest: XCTestCase {
+
+    private var mock: Nested.MockNestedTestedClass!
+
+    override func setUp() {
+        super.setUp()
+
+        mock = Nested.MockNestedTestedClass()
+    }
+
+    func testReadOnlyPropertyWithMockCreator() {
+        let mock = createMock(for: Nested.NestedTestedClass.self) { builder, stub in
+            when(stub.readOnlyProperty.get).thenReturn("a")
+
+            return Nested.MockNestedTestedClass()
+        }
+
+        XCTAssertEqual(mock.readOnlyProperty, "a")
+        verify(mock).readOnlyProperty.get()
+    }
+
+    func testReadOnlyProperty() {
+        let mock = Nested.MockNestedTestedClass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyProperty, "a")
+        verify(mock).readOnlyProperty.get()
+    }
+
+    func testReadOnlyOptionalProperty() {
+        let mock = Nested.MockNestedTestedClass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyOptionalProperty, "a")
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testOptionalReadOnlyPropertyIsNil() {
+        let mock = Nested.MockNestedTestedClass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn(nil)
+        }
+
+        XCTAssertNil(mock.readOnlyOptionalProperty)
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testReadWriteProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.readWriteProperty.get).thenReturn(1)
+            when(mock.readWriteProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.readWriteProperty = 0
+
+        XCTAssertEqual(mock.readWriteProperty, 1)
+        XCTAssertTrue(called)
+        verify(mock).readWriteProperty.get()
+        verify(mock).readWriteProperty.set(0)
+    }
+
+    func testOptionalProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.optionalProperty.get).thenReturn(nil)
+            when(mock.optionalProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.optionalProperty = 0
+
+        XCTAssertNil(mock.optionalProperty)
+        XCTAssertTrue(called)
+        verify(mock).optionalProperty.get()
+        verify(mock).optionalProperty.set(equal(to: 0))
+    }
+
+    func testNoReturn() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.noReturn()).then { _ in called = true }
+        }
+
+        mock.noReturn()
+
+        XCTAssertTrue(called)
+        verify(mock).noReturn()
+    }
+
+    func testCountCharacters() {
+        stub(mock) { mock in
+            when(mock.count(characters: "a")).thenReturn(1)
+        }
+
+        XCTAssertEqual(mock.count(characters: "a"), 1)
+        verify(mock).count(characters: "a")
+    }
+
+    func testWithThrows() {
+        stub(mock) { mock in
+            when(mock.withThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            _ = try mock.withThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withThrows()
+    }
+
+    func testWithNoReturnThrows() {
+        stub(mock) { mock in
+            when(mock.withNoReturnThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            try mock.withNoReturnThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withNoReturnThrows()
+    }
+
+    func testWithClosure() {
+        func anyNestedClosure<IN1, IN2, OUT>() -> ParameterMatcher<((IN1) -> IN2) -> OUT> {
+            return ParameterMatcher()
+        }
+
+        stub(mock) { mock in
+            when(mock.withClosure(anyClosure())).then { $0("a") }
+            when(mock.withClosureReturningVoid(anyClosure())).then { $0("a")() }
+            when(mock.withClosureReturningInt(anyClosure())).then { $0("a")(1) }
+            when(mock.withOptionalClosureAlone(anyClosure())).then { $0?("a")(1) ?? 1 }
+            when(mock.withNestedClosure1(anyClosure())).then { $0("a")({ Int($0) ?? 1 }) }
+            when(mock.withNestedClosure2(anyNestedClosure())).then { $0({ Int($0) ?? 1 })({ Int($0) ?? 1 }) }
+        }
+
+        XCTAssertEqual(mock.withClosure { _ in 1 }, 1)
+        XCTAssertEqual(mock.withClosureReturningVoid {_ in { return 1 } }, 1)
+        XCTAssertEqual(mock.withClosureReturningInt { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withOptionalClosureAlone { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure1 { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure2 { _ in { _ in return 1 } }, 1)
+
+        verify(mock).withClosure(anyClosure())
+        verify(mock).withClosureReturningVoid(anyClosure())
+        verify(mock).withClosureReturningInt(anyClosure())
+        verify(mock).withOptionalClosureAlone(anyClosure())
+        verify(mock).withNestedClosure1(anyClosure())
+        verify(mock).withNestedClosure2(anyNestedClosure())
+    }
+
+    func testWithEscape() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withEscape(anyString(), action: anyClosure())).then { text, closure in closure(text) }
+        }
+
+        mock.withEscape("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withEscape(anyString(), action: anyClosure())
+    }
+
+    func testWithOptionalClosure() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withOptionalClosure(anyString(), closure: anyClosure())).then { text, closure in closure?(text)  }
+        }
+
+        mock.withOptionalClosure("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withOptionalClosure(anyString(), closure: anyClosure())
+    }
+
+    func testWithLabel() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withLabelAndUnderscore(labelA: anyString(), anyString())).then { _ in called = true }
+        }
+
+        mock.withLabelAndUnderscore(labelA: "a", "b")
+        XCTAssertTrue(called)
+        verify(mock).withLabelAndUnderscore(labelA: anyString(), anyString())
+    }
+
+    func testCallingCountCharactersMethodWithHello() {
+        stub(mock) { mock in
+            when(mock.callingCountCharactersMethodWithHello()).thenCallRealImplementation()
+            when(mock.count(characters: any())).thenReturn(0)
+        }
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+        verify(mock).count(characters: "Hello")
+    }
+
+    func testDefaultImplCall() {
+        mock.enableDefaultImplementation(Nested.NestedTestedClassStub())
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+    }
+}

--- a/Tests/Swift/NestedClassTest.swift
+++ b/Tests/Swift/NestedClassTest.swift
@@ -2,7 +2,7 @@
 //  NestedClassTest.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/17/20.
+//  Created by Tyler Thompson on 9/17/20.
 //
 
 import XCTest

--- a/Tests/Swift/NestedExtensionClassTest.swift
+++ b/Tests/Swift/NestedExtensionClassTest.swift
@@ -1,0 +1,234 @@
+////
+////  NestedExtensionClassTest.swift
+////  Cuckoo
+////
+////  Created by thompsty on 9/18/20.
+////
+//
+//import Foundation
+//import XCTest
+//import Cuckoo
+//
+//extension Nested.NestedExtensionTestedClass: Mocked {
+//    typealias MockType = Nested.MockNestedExtensionTestedClass
+//}
+//
+//class NestedExtensionClassTests: XCTestCase {
+//
+//    private var mock: Nested.MockNestedExtensionTestedClass!
+//
+//    override func setUp() {
+//        super.setUp()
+//
+//        mock = Nested.MockNestedExtensionTestedClass()
+//    }
+//
+//    func testReadOnlyPropertyWithMockCreator() {
+//        let mock = createMock(for: Nested.NestedExtensionTestedClass.self) { builder, stub in
+//            when(stub.readOnlyProperty.get).thenReturn("a")
+//
+//            return Nested.MockNestedExtensionTestedClass()
+//        }
+//
+//        XCTAssertEqual(mock.readOnlyProperty, "a")
+//        verify(mock).readOnlyProperty.get()
+//    }
+//
+//    func testReadOnlyProperty() {
+//        let mock = Nested.MockNestedExtensionTestedClass()
+//
+//        stub(mock) { mock in
+//            when(mock.readOnlyProperty.get).thenReturn("a")
+//        }
+//
+//        XCTAssertEqual(mock.readOnlyProperty, "a")
+//        verify(mock).readOnlyProperty.get()
+//    }
+//
+//    func testReadOnlyOptionalProperty() {
+//        let mock = Nested.MockNestedExtensionTestedClass()
+//
+//        stub(mock) { mock in
+//            when(mock.readOnlyOptionalProperty.get).thenReturn("a")
+//        }
+//
+//        XCTAssertEqual(mock.readOnlyOptionalProperty, "a")
+//        verify(mock).readOnlyOptionalProperty.get()
+//    }
+//
+//    func testOptionalReadOnlyPropertyIsNil() {
+//        let mock = Nested.MockNestedExtensionTestedClass()
+//
+//        stub(mock) { mock in
+//            when(mock.readOnlyOptionalProperty.get).thenReturn(nil)
+//        }
+//
+//        XCTAssertNil(mock.readOnlyOptionalProperty)
+//        verify(mock).readOnlyOptionalProperty.get()
+//    }
+//
+//    func testReadWriteProperty() {
+//        var called = false
+//        stub(mock) { mock in
+//            when(mock.readWriteProperty.get).thenReturn(1)
+//            when(mock.readWriteProperty.set(anyInt())).then { _ in called = true }
+//        }
+//
+//        mock.readWriteProperty = 0
+//
+//        XCTAssertEqual(mock.readWriteProperty, 1)
+//        XCTAssertTrue(called)
+//        verify(mock).readWriteProperty.get()
+//        verify(mock).readWriteProperty.set(0)
+//    }
+//
+//    func testOptionalProperty() {
+//        var called = false
+//        stub(mock) { mock in
+//            when(mock.optionalProperty.get).thenReturn(nil)
+//            when(mock.optionalProperty.set(anyInt())).then { _ in called = true }
+//        }
+//
+//        mock.optionalProperty = 0
+//
+//        XCTAssertNil(mock.optionalProperty)
+//        XCTAssertTrue(called)
+//        verify(mock).optionalProperty.get()
+//        verify(mock).optionalProperty.set(equal(to: 0))
+//    }
+//
+//    func testNoReturn() {
+//        var called = false
+//        stub(mock) { mock in
+//            when(mock.noReturn()).then { _ in called = true }
+//        }
+//
+//        mock.noReturn()
+//
+//        XCTAssertTrue(called)
+//        verify(mock).noReturn()
+//    }
+//
+//    func testCountCharacters() {
+//        stub(mock) { mock in
+//            when(mock.count(characters: "a")).thenReturn(1)
+//        }
+//
+//        XCTAssertEqual(mock.count(characters: "a"), 1)
+//        verify(mock).count(characters: "a")
+//    }
+//
+//    func testWithThrows() {
+//        stub(mock) { mock in
+//            when(mock.withThrows()).thenThrow(TestError.unknown)
+//        }
+//
+//        var catched = false
+//        do {
+//            _ = try mock.withThrows()
+//        } catch {
+//            catched = true
+//        }
+//
+//        XCTAssertTrue(catched)
+//        verify(mock).withThrows()
+//    }
+//
+//    func testWithNoReturnThrows() {
+//        stub(mock) { mock in
+//            when(mock.withNoReturnThrows()).thenThrow(TestError.unknown)
+//        }
+//
+//        var catched = false
+//        do {
+//            try mock.withNoReturnThrows()
+//        } catch {
+//            catched = true
+//        }
+//
+//        XCTAssertTrue(catched)
+//        verify(mock).withNoReturnThrows()
+//    }
+//
+//    func testWithClosure() {
+//        func anyNestedClosure<IN1, IN2, OUT>() -> ParameterMatcher<((IN1) -> IN2) -> OUT> {
+//            return ParameterMatcher()
+//        }
+//
+//        stub(mock) { mock in
+//            when(mock.withClosure(anyClosure())).then { $0("a") }
+//            when(mock.withClosureReturningVoid(anyClosure())).then { $0("a")() }
+//            when(mock.withClosureReturningInt(anyClosure())).then { $0("a")(1) }
+//            when(mock.withOptionalClosureAlone(anyClosure())).then { $0?("a")(1) ?? 1 }
+//            when(mock.withNestedClosure1(anyClosure())).then { $0("a")({ Int($0) ?? 1 }) }
+//            when(mock.withNestedClosure2(anyNestedClosure())).then { $0({ Int($0) ?? 1 })({ Int($0) ?? 1 }) }
+//        }
+//
+//        XCTAssertEqual(mock.withClosure { _ in 1 }, 1)
+//        XCTAssertEqual(mock.withClosureReturningVoid {_ in { return 1 } }, 1)
+//        XCTAssertEqual(mock.withClosureReturningInt { _ in { _ in return 1 } }, 1)
+//        XCTAssertEqual(mock.withOptionalClosureAlone { _ in { _ in return 1 } }, 1)
+//        XCTAssertEqual(mock.withNestedClosure1 { _ in { _ in return 1 } }, 1)
+//        XCTAssertEqual(mock.withNestedClosure2 { _ in { _ in return 1 } }, 1)
+//
+//        verify(mock).withClosure(anyClosure())
+//        verify(mock).withClosureReturningVoid(anyClosure())
+//        verify(mock).withClosureReturningInt(anyClosure())
+//        verify(mock).withOptionalClosureAlone(anyClosure())
+//        verify(mock).withNestedClosure1(anyClosure())
+//        verify(mock).withNestedClosure2(anyNestedClosure())
+//    }
+//
+//    func testWithEscape() {
+//        var called = false
+//        stub(mock) { mock in
+//            when(mock.withEscape(anyString(), action: anyClosure())).then { text, closure in closure(text) }
+//        }
+//
+//        mock.withEscape("a") { called = $0 == "a" }
+//
+//        XCTAssertTrue(called)
+//        verify(mock).withEscape(anyString(), action: anyClosure())
+//    }
+//
+//    func testWithOptionalClosure() {
+//        var called = false
+//        stub(mock) { mock in
+//            when(mock.withOptionalClosure(anyString(), closure: anyClosure())).then { text, closure in closure?(text)  }
+//        }
+//
+//        mock.withOptionalClosure("a") { called = $0 == "a" }
+//
+//        XCTAssertTrue(called)
+//        verify(mock).withOptionalClosure(anyString(), closure: anyClosure())
+//    }
+//
+//    func testWithLabel() {
+//        var called = false
+//        stub(mock) { mock in
+//            when(mock.withLabelAndUnderscore(labelA: anyString(), anyString())).then { _ in called = true }
+//        }
+//
+//        mock.withLabelAndUnderscore(labelA: "a", "b")
+//        XCTAssertTrue(called)
+//        verify(mock).withLabelAndUnderscore(labelA: anyString(), anyString())
+//    }
+//
+//    func testCallingCountCharactersMethodWithHello() {
+//        stub(mock) { mock in
+//            when(mock.callingCountCharactersMethodWithHello()).thenCallRealImplementation()
+//            when(mock.count(characters: any())).thenReturn(0)
+//        }
+//
+//        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+//        verify(mock).callingCountCharactersMethodWithHello()
+//        verify(mock).count(characters: "Hello")
+//    }
+//
+//    func testDefaultImplCall() {
+//        mock.enableDefaultImplementation(Nested.NestedExtensionTestedClassStub())
+//
+//        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+//        verify(mock).callingCountCharactersMethodWithHello()
+//    }
+//}

--- a/Tests/Swift/NestedExtensionClassTest.swift
+++ b/Tests/Swift/NestedExtensionClassTest.swift
@@ -1,234 +1,234 @@
-////
-////  NestedExtensionClassTest.swift
-////  Cuckoo
-////
-////  Created by thompsty on 9/18/20.
-////
 //
-//import Foundation
-//import XCTest
-//import Cuckoo
+//  NestedExtensionClassTest.swift
+//  Cuckoo
 //
-//extension Nested.NestedExtensionTestedClass: Mocked {
-//    typealias MockType = Nested.MockNestedExtensionTestedClass
-//}
+//  Created by thompsty on 9/18/20.
 //
-//class NestedExtensionClassTests: XCTestCase {
-//
-//    private var mock: Nested.MockNestedExtensionTestedClass!
-//
-//    override func setUp() {
-//        super.setUp()
-//
-//        mock = Nested.MockNestedExtensionTestedClass()
-//    }
-//
-//    func testReadOnlyPropertyWithMockCreator() {
-//        let mock = createMock(for: Nested.NestedExtensionTestedClass.self) { builder, stub in
-//            when(stub.readOnlyProperty.get).thenReturn("a")
-//
-//            return Nested.MockNestedExtensionTestedClass()
-//        }
-//
-//        XCTAssertEqual(mock.readOnlyProperty, "a")
-//        verify(mock).readOnlyProperty.get()
-//    }
-//
-//    func testReadOnlyProperty() {
-//        let mock = Nested.MockNestedExtensionTestedClass()
-//
-//        stub(mock) { mock in
-//            when(mock.readOnlyProperty.get).thenReturn("a")
-//        }
-//
-//        XCTAssertEqual(mock.readOnlyProperty, "a")
-//        verify(mock).readOnlyProperty.get()
-//    }
-//
-//    func testReadOnlyOptionalProperty() {
-//        let mock = Nested.MockNestedExtensionTestedClass()
-//
-//        stub(mock) { mock in
-//            when(mock.readOnlyOptionalProperty.get).thenReturn("a")
-//        }
-//
-//        XCTAssertEqual(mock.readOnlyOptionalProperty, "a")
-//        verify(mock).readOnlyOptionalProperty.get()
-//    }
-//
-//    func testOptionalReadOnlyPropertyIsNil() {
-//        let mock = Nested.MockNestedExtensionTestedClass()
-//
-//        stub(mock) { mock in
-//            when(mock.readOnlyOptionalProperty.get).thenReturn(nil)
-//        }
-//
-//        XCTAssertNil(mock.readOnlyOptionalProperty)
-//        verify(mock).readOnlyOptionalProperty.get()
-//    }
-//
-//    func testReadWriteProperty() {
-//        var called = false
-//        stub(mock) { mock in
-//            when(mock.readWriteProperty.get).thenReturn(1)
-//            when(mock.readWriteProperty.set(anyInt())).then { _ in called = true }
-//        }
-//
-//        mock.readWriteProperty = 0
-//
-//        XCTAssertEqual(mock.readWriteProperty, 1)
-//        XCTAssertTrue(called)
-//        verify(mock).readWriteProperty.get()
-//        verify(mock).readWriteProperty.set(0)
-//    }
-//
-//    func testOptionalProperty() {
-//        var called = false
-//        stub(mock) { mock in
-//            when(mock.optionalProperty.get).thenReturn(nil)
-//            when(mock.optionalProperty.set(anyInt())).then { _ in called = true }
-//        }
-//
-//        mock.optionalProperty = 0
-//
-//        XCTAssertNil(mock.optionalProperty)
-//        XCTAssertTrue(called)
-//        verify(mock).optionalProperty.get()
-//        verify(mock).optionalProperty.set(equal(to: 0))
-//    }
-//
-//    func testNoReturn() {
-//        var called = false
-//        stub(mock) { mock in
-//            when(mock.noReturn()).then { _ in called = true }
-//        }
-//
-//        mock.noReturn()
-//
-//        XCTAssertTrue(called)
-//        verify(mock).noReturn()
-//    }
-//
-//    func testCountCharacters() {
-//        stub(mock) { mock in
-//            when(mock.count(characters: "a")).thenReturn(1)
-//        }
-//
-//        XCTAssertEqual(mock.count(characters: "a"), 1)
-//        verify(mock).count(characters: "a")
-//    }
-//
-//    func testWithThrows() {
-//        stub(mock) { mock in
-//            when(mock.withThrows()).thenThrow(TestError.unknown)
-//        }
-//
-//        var catched = false
-//        do {
-//            _ = try mock.withThrows()
-//        } catch {
-//            catched = true
-//        }
-//
-//        XCTAssertTrue(catched)
-//        verify(mock).withThrows()
-//    }
-//
-//    func testWithNoReturnThrows() {
-//        stub(mock) { mock in
-//            when(mock.withNoReturnThrows()).thenThrow(TestError.unknown)
-//        }
-//
-//        var catched = false
-//        do {
-//            try mock.withNoReturnThrows()
-//        } catch {
-//            catched = true
-//        }
-//
-//        XCTAssertTrue(catched)
-//        verify(mock).withNoReturnThrows()
-//    }
-//
-//    func testWithClosure() {
-//        func anyNestedClosure<IN1, IN2, OUT>() -> ParameterMatcher<((IN1) -> IN2) -> OUT> {
-//            return ParameterMatcher()
-//        }
-//
-//        stub(mock) { mock in
-//            when(mock.withClosure(anyClosure())).then { $0("a") }
-//            when(mock.withClosureReturningVoid(anyClosure())).then { $0("a")() }
-//            when(mock.withClosureReturningInt(anyClosure())).then { $0("a")(1) }
-//            when(mock.withOptionalClosureAlone(anyClosure())).then { $0?("a")(1) ?? 1 }
-//            when(mock.withNestedClosure1(anyClosure())).then { $0("a")({ Int($0) ?? 1 }) }
-//            when(mock.withNestedClosure2(anyNestedClosure())).then { $0({ Int($0) ?? 1 })({ Int($0) ?? 1 }) }
-//        }
-//
-//        XCTAssertEqual(mock.withClosure { _ in 1 }, 1)
-//        XCTAssertEqual(mock.withClosureReturningVoid {_ in { return 1 } }, 1)
-//        XCTAssertEqual(mock.withClosureReturningInt { _ in { _ in return 1 } }, 1)
-//        XCTAssertEqual(mock.withOptionalClosureAlone { _ in { _ in return 1 } }, 1)
-//        XCTAssertEqual(mock.withNestedClosure1 { _ in { _ in return 1 } }, 1)
-//        XCTAssertEqual(mock.withNestedClosure2 { _ in { _ in return 1 } }, 1)
-//
-//        verify(mock).withClosure(anyClosure())
-//        verify(mock).withClosureReturningVoid(anyClosure())
-//        verify(mock).withClosureReturningInt(anyClosure())
-//        verify(mock).withOptionalClosureAlone(anyClosure())
-//        verify(mock).withNestedClosure1(anyClosure())
-//        verify(mock).withNestedClosure2(anyNestedClosure())
-//    }
-//
-//    func testWithEscape() {
-//        var called = false
-//        stub(mock) { mock in
-//            when(mock.withEscape(anyString(), action: anyClosure())).then { text, closure in closure(text) }
-//        }
-//
-//        mock.withEscape("a") { called = $0 == "a" }
-//
-//        XCTAssertTrue(called)
-//        verify(mock).withEscape(anyString(), action: anyClosure())
-//    }
-//
-//    func testWithOptionalClosure() {
-//        var called = false
-//        stub(mock) { mock in
-//            when(mock.withOptionalClosure(anyString(), closure: anyClosure())).then { text, closure in closure?(text)  }
-//        }
-//
-//        mock.withOptionalClosure("a") { called = $0 == "a" }
-//
-//        XCTAssertTrue(called)
-//        verify(mock).withOptionalClosure(anyString(), closure: anyClosure())
-//    }
-//
-//    func testWithLabel() {
-//        var called = false
-//        stub(mock) { mock in
-//            when(mock.withLabelAndUnderscore(labelA: anyString(), anyString())).then { _ in called = true }
-//        }
-//
-//        mock.withLabelAndUnderscore(labelA: "a", "b")
-//        XCTAssertTrue(called)
-//        verify(mock).withLabelAndUnderscore(labelA: anyString(), anyString())
-//    }
-//
-//    func testCallingCountCharactersMethodWithHello() {
-//        stub(mock) { mock in
-//            when(mock.callingCountCharactersMethodWithHello()).thenCallRealImplementation()
-//            when(mock.count(characters: any())).thenReturn(0)
-//        }
-//
-//        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
-//        verify(mock).callingCountCharactersMethodWithHello()
-//        verify(mock).count(characters: "Hello")
-//    }
-//
-//    func testDefaultImplCall() {
-//        mock.enableDefaultImplementation(Nested.NestedExtensionTestedClassStub())
-//
-//        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
-//        verify(mock).callingCountCharactersMethodWithHello()
-//    }
-//}
+
+import Foundation
+import XCTest
+import Cuckoo
+
+extension Nested.NestedExtensionTestedClass: Mocked {
+    typealias MockType = Nested.MockNestedExtensionTestedClass
+}
+
+class NestedExtensionClassTests: XCTestCase {
+
+    private var mock: Nested.MockNestedExtensionTestedClass!
+
+    override func setUp() {
+        super.setUp()
+
+        mock = Nested.MockNestedExtensionTestedClass()
+    }
+
+    func testReadOnlyPropertyWithMockCreator() {
+        let mock = createMock(for: Nested.NestedExtensionTestedClass.self) { builder, stub in
+            when(stub.readOnlyProperty.get).thenReturn("a")
+
+            return Nested.MockNestedExtensionTestedClass()
+        }
+
+        XCTAssertEqual(mock.readOnlyProperty, "a")
+        verify(mock).readOnlyProperty.get()
+    }
+
+    func testReadOnlyProperty() {
+        let mock = Nested.MockNestedExtensionTestedClass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyProperty, "a")
+        verify(mock).readOnlyProperty.get()
+    }
+
+    func testReadOnlyOptionalProperty() {
+        let mock = Nested.MockNestedExtensionTestedClass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyOptionalProperty, "a")
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testOptionalReadOnlyPropertyIsNil() {
+        let mock = Nested.MockNestedExtensionTestedClass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn(nil)
+        }
+
+        XCTAssertNil(mock.readOnlyOptionalProperty)
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testReadWriteProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.readWriteProperty.get).thenReturn(1)
+            when(mock.readWriteProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.readWriteProperty = 0
+
+        XCTAssertEqual(mock.readWriteProperty, 1)
+        XCTAssertTrue(called)
+        verify(mock).readWriteProperty.get()
+        verify(mock).readWriteProperty.set(0)
+    }
+
+    func testOptionalProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.optionalProperty.get).thenReturn(nil)
+            when(mock.optionalProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.optionalProperty = 0
+
+        XCTAssertNil(mock.optionalProperty)
+        XCTAssertTrue(called)
+        verify(mock).optionalProperty.get()
+        verify(mock).optionalProperty.set(equal(to: 0))
+    }
+
+    func testNoReturn() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.noReturn()).then { _ in called = true }
+        }
+
+        mock.noReturn()
+
+        XCTAssertTrue(called)
+        verify(mock).noReturn()
+    }
+
+    func testCountCharacters() {
+        stub(mock) { mock in
+            when(mock.count(characters: "a")).thenReturn(1)
+        }
+
+        XCTAssertEqual(mock.count(characters: "a"), 1)
+        verify(mock).count(characters: "a")
+    }
+
+    func testWithThrows() {
+        stub(mock) { mock in
+            when(mock.withThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            _ = try mock.withThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withThrows()
+    }
+
+    func testWithNoReturnThrows() {
+        stub(mock) { mock in
+            when(mock.withNoReturnThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            try mock.withNoReturnThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withNoReturnThrows()
+    }
+
+    func testWithClosure() {
+        func anyNestedClosure<IN1, IN2, OUT>() -> ParameterMatcher<((IN1) -> IN2) -> OUT> {
+            return ParameterMatcher()
+        }
+
+        stub(mock) { mock in
+            when(mock.withClosure(anyClosure())).then { $0("a") }
+            when(mock.withClosureReturningVoid(anyClosure())).then { $0("a")() }
+            when(mock.withClosureReturningInt(anyClosure())).then { $0("a")(1) }
+            when(mock.withOptionalClosureAlone(anyClosure())).then { $0?("a")(1) ?? 1 }
+            when(mock.withNestedClosure1(anyClosure())).then { $0("a")({ Int($0) ?? 1 }) }
+            when(mock.withNestedClosure2(anyNestedClosure())).then { $0({ Int($0) ?? 1 })({ Int($0) ?? 1 }) }
+        }
+
+        XCTAssertEqual(mock.withClosure { _ in 1 }, 1)
+        XCTAssertEqual(mock.withClosureReturningVoid {_ in { return 1 } }, 1)
+        XCTAssertEqual(mock.withClosureReturningInt { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withOptionalClosureAlone { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure1 { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure2 { _ in { _ in return 1 } }, 1)
+
+        verify(mock).withClosure(anyClosure())
+        verify(mock).withClosureReturningVoid(anyClosure())
+        verify(mock).withClosureReturningInt(anyClosure())
+        verify(mock).withOptionalClosureAlone(anyClosure())
+        verify(mock).withNestedClosure1(anyClosure())
+        verify(mock).withNestedClosure2(anyNestedClosure())
+    }
+
+    func testWithEscape() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withEscape(anyString(), action: anyClosure())).then { text, closure in closure(text) }
+        }
+
+        mock.withEscape("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withEscape(anyString(), action: anyClosure())
+    }
+
+    func testWithOptionalClosure() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withOptionalClosure(anyString(), closure: anyClosure())).then { text, closure in closure?(text)  }
+        }
+
+        mock.withOptionalClosure("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withOptionalClosure(anyString(), closure: anyClosure())
+    }
+
+    func testWithLabel() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withLabelAndUnderscore(labelA: anyString(), anyString())).then { _ in called = true }
+        }
+
+        mock.withLabelAndUnderscore(labelA: "a", "b")
+        XCTAssertTrue(called)
+        verify(mock).withLabelAndUnderscore(labelA: anyString(), anyString())
+    }
+
+    func testCallingCountCharactersMethodWithHello() {
+        stub(mock) { mock in
+            when(mock.callingCountCharactersMethodWithHello()).thenCallRealImplementation()
+            when(mock.count(characters: any())).thenReturn(0)
+        }
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+        verify(mock).count(characters: "Hello")
+    }
+
+    func testDefaultImplCall() {
+        mock.enableDefaultImplementation(Nested.NestedExtensionTestedClassStub())
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+    }
+}

--- a/Tests/Swift/NestedExtensionClassTest.swift
+++ b/Tests/Swift/NestedExtensionClassTest.swift
@@ -2,7 +2,7 @@
 //  NestedExtensionClassTest.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/NestedPrivateClassTest.swift
+++ b/Tests/Swift/NestedPrivateClassTest.swift
@@ -1,0 +1,8 @@
+//
+//  NestedPrivateClassTest.swift
+//  Cuckoo
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation

--- a/Tests/Swift/NestedPrivateClassTest.swift
+++ b/Tests/Swift/NestedPrivateClassTest.swift
@@ -1,8 +1,0 @@
-//
-//  NestedPrivateClassTest.swift
-//  Cuckoo
-//
-//  Created by thompsty on 9/18/20.
-//
-
-import Foundation

--- a/Tests/Swift/NestedPrivateExtensionClassTest.swift
+++ b/Tests/Swift/NestedPrivateExtensionClassTest.swift
@@ -1,8 +1,0 @@
-//
-//  NestedPrivateExtensionClassTest.swift
-//  Cuckoo
-//
-//  Created by thompsty on 9/18/20.
-//
-
-import Foundation

--- a/Tests/Swift/NestedPrivateExtensionClassTest.swift
+++ b/Tests/Swift/NestedPrivateExtensionClassTest.swift
@@ -1,0 +1,8 @@
+//
+//  NestedPrivateExtensionClassTest.swift
+//  Cuckoo
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation

--- a/Tests/Swift/NestedStructExtensionClassTest.swift
+++ b/Tests/Swift/NestedStructExtensionClassTest.swift
@@ -1,0 +1,219 @@
+//
+//  NestedStructExtensionClassTest.swift
+//  Cuckoo
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+import XCTest
+import Cuckoo
+
+class NestedStructExtensionClassTests: XCTestCase {
+
+    private var mock: NestedStruct.MockNestedExtensionTestedClass!
+
+    override func setUp() {
+        super.setUp()
+
+        mock = NestedStruct.MockNestedExtensionTestedClass()
+    }
+
+    func testReadOnlyProperty() {
+        let mock = NestedStruct.MockNestedExtensionTestedClass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyProperty, "a")
+        verify(mock).readOnlyProperty.get()
+    }
+
+    func testReadOnlyOptionalProperty() {
+        let mock = NestedStruct.MockNestedExtensionTestedClass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyOptionalProperty, "a")
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testOptionalReadOnlyPropertyIsNil() {
+        let mock = NestedStruct.MockNestedExtensionTestedClass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn(nil)
+        }
+
+        XCTAssertNil(mock.readOnlyOptionalProperty)
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testReadWriteProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.readWriteProperty.get).thenReturn(1)
+            when(mock.readWriteProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.readWriteProperty = 0
+
+        XCTAssertEqual(mock.readWriteProperty, 1)
+        XCTAssertTrue(called)
+        verify(mock).readWriteProperty.get()
+        verify(mock).readWriteProperty.set(0)
+    }
+
+    func testOptionalProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.optionalProperty.get).thenReturn(nil)
+            when(mock.optionalProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.optionalProperty = 0
+
+        XCTAssertNil(mock.optionalProperty)
+        XCTAssertTrue(called)
+        verify(mock).optionalProperty.get()
+        verify(mock).optionalProperty.set(equal(to: 0))
+    }
+
+    func testNoReturn() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.noReturn()).then { _ in called = true }
+        }
+
+        mock.noReturn()
+
+        XCTAssertTrue(called)
+        verify(mock).noReturn()
+    }
+
+    func testCountCharacters() {
+        stub(mock) { mock in
+            when(mock.count(characters: "a")).thenReturn(1)
+        }
+
+        XCTAssertEqual(mock.count(characters: "a"), 1)
+        verify(mock).count(characters: "a")
+    }
+
+    func testWithThrows() {
+        stub(mock) { mock in
+            when(mock.withThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            _ = try mock.withThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withThrows()
+    }
+
+    func testWithNoReturnThrows() {
+        stub(mock) { mock in
+            when(mock.withNoReturnThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            try mock.withNoReturnThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withNoReturnThrows()
+    }
+
+    func testWithClosure() {
+        func anyNestedClosure<IN1, IN2, OUT>() -> ParameterMatcher<((IN1) -> IN2) -> OUT> {
+            return ParameterMatcher()
+        }
+
+        stub(mock) { mock in
+            when(mock.withClosure(anyClosure())).then { $0("a") }
+            when(mock.withClosureReturningVoid(anyClosure())).then { $0("a")() }
+            when(mock.withClosureReturningInt(anyClosure())).then { $0("a")(1) }
+            when(mock.withOptionalClosureAlone(anyClosure())).then { $0?("a")(1) ?? 1 }
+            when(mock.withNestedClosure1(anyClosure())).then { $0("a")({ Int($0) ?? 1 }) }
+            when(mock.withNestedClosure2(anyNestedClosure())).then { $0({ Int($0) ?? 1 })({ Int($0) ?? 1 }) }
+        }
+
+        XCTAssertEqual(mock.withClosure { _ in 1 }, 1)
+        XCTAssertEqual(mock.withClosureReturningVoid {_ in { return 1 } }, 1)
+        XCTAssertEqual(mock.withClosureReturningInt { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withOptionalClosureAlone { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure1 { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure2 { _ in { _ in return 1 } }, 1)
+
+        verify(mock).withClosure(anyClosure())
+        verify(mock).withClosureReturningVoid(anyClosure())
+        verify(mock).withClosureReturningInt(anyClosure())
+        verify(mock).withOptionalClosureAlone(anyClosure())
+        verify(mock).withNestedClosure1(anyClosure())
+        verify(mock).withNestedClosure2(anyNestedClosure())
+    }
+
+    func testWithEscape() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withEscape(anyString(), action: anyClosure())).then { text, closure in closure(text) }
+        }
+
+        mock.withEscape("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withEscape(anyString(), action: anyClosure())
+    }
+
+    func testWithOptionalClosure() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withOptionalClosure(anyString(), closure: anyClosure())).then { text, closure in closure?(text)  }
+        }
+
+        mock.withOptionalClosure("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withOptionalClosure(anyString(), closure: anyClosure())
+    }
+
+    func testWithLabel() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withLabelAndUnderscore(labelA: anyString(), anyString())).then { _ in called = true }
+        }
+
+        mock.withLabelAndUnderscore(labelA: "a", "b")
+        XCTAssertTrue(called)
+        verify(mock).withLabelAndUnderscore(labelA: anyString(), anyString())
+    }
+
+    func testCallingCountCharactersMethodWithHello() {
+        stub(mock) { mock in
+            when(mock.callingCountCharactersMethodWithHello()).thenCallRealImplementation()
+            when(mock.count(characters: any())).thenReturn(0)
+        }
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+        verify(mock).count(characters: "Hello")
+    }
+
+    func testDefaultImplCall() {
+        mock.enableDefaultImplementation(NestedStruct.NestedExtensionTestedClassStub())
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+    }
+}

--- a/Tests/Swift/NestedStructExtensionClassTest.swift
+++ b/Tests/Swift/NestedStructExtensionClassTest.swift
@@ -2,7 +2,7 @@
 //  NestedStructExtensionClassTest.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/NestedStructTest.swift
+++ b/Tests/Swift/NestedStructTest.swift
@@ -1,0 +1,219 @@
+//
+//  NestedStructTest.swift
+//  Cuckoo
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+import XCTest
+import Cuckoo
+
+class NestedStructSubclassTest: XCTestCase {
+
+    private var mock: NestedStruct.MockNestedTestedSubclass!
+
+    override func setUp() {
+        super.setUp()
+
+        mock = NestedStruct.MockNestedTestedSubclass()
+    }
+
+    func testReadOnlyProperty() {
+        let mock = NestedStruct.MockNestedTestedSubclass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyProperty, "a")
+        verify(mock).readOnlyProperty.get()
+    }
+
+    func testReadOnlyOptionalProperty() {
+        let mock = NestedStruct.MockNestedTestedSubclass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyOptionalProperty, "a")
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testOptionalReadOnlyPropertyIsNil() {
+        let mock = NestedStruct.MockNestedTestedSubclass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn(nil)
+        }
+
+        XCTAssertNil(mock.readOnlyOptionalProperty)
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testReadWriteProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.readWriteProperty.get).thenReturn(1)
+            when(mock.readWriteProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.readWriteProperty = 0
+
+        XCTAssertEqual(mock.readWriteProperty, 1)
+        XCTAssertTrue(called)
+        verify(mock).readWriteProperty.get()
+        verify(mock).readWriteProperty.set(0)
+    }
+
+    func testOptionalProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.optionalProperty.get).thenReturn(nil)
+            when(mock.optionalProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.optionalProperty = 0
+
+        XCTAssertNil(mock.optionalProperty)
+        XCTAssertTrue(called)
+        verify(mock).optionalProperty.get()
+        verify(mock).optionalProperty.set(equal(to: 0))
+    }
+
+    func testNoReturn() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.noReturn()).then { _ in called = true }
+        }
+
+        mock.noReturn()
+
+        XCTAssertTrue(called)
+        verify(mock).noReturn()
+    }
+
+    func testCountCharacters() {
+        stub(mock) { mock in
+            when(mock.count(characters: "a")).thenReturn(1)
+        }
+
+        XCTAssertEqual(mock.count(characters: "a"), 1)
+        verify(mock).count(characters: "a")
+    }
+
+    func testWithThrows() {
+        stub(mock) { mock in
+            when(mock.withThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            _ = try mock.withThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withThrows()
+    }
+
+    func testWithNoReturnThrows() {
+        stub(mock) { mock in
+            when(mock.withNoReturnThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            try mock.withNoReturnThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withNoReturnThrows()
+    }
+
+    func testWithClosure() {
+        func anyNestedClosure<IN1, IN2, OUT>() -> ParameterMatcher<((IN1) -> IN2) -> OUT> {
+            return ParameterMatcher()
+        }
+
+        stub(mock) { mock in
+            when(mock.withClosure(anyClosure())).then { $0("a") }
+            when(mock.withClosureReturningVoid(anyClosure())).then { $0("a")() }
+            when(mock.withClosureReturningInt(anyClosure())).then { $0("a")(1) }
+            when(mock.withOptionalClosureAlone(anyClosure())).then { $0?("a")(1) ?? 1 }
+            when(mock.withNestedClosure1(anyClosure())).then { $0("a")({ Int($0) ?? 1 }) }
+            when(mock.withNestedClosure2(anyNestedClosure())).then { $0({ Int($0) ?? 1 })({ Int($0) ?? 1 }) }
+        }
+
+        XCTAssertEqual(mock.withClosure { _ in 1 }, 1)
+        XCTAssertEqual(mock.withClosureReturningVoid {_ in { return 1 } }, 1)
+        XCTAssertEqual(mock.withClosureReturningInt { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withOptionalClosureAlone { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure1 { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure2 { _ in { _ in return 1 } }, 1)
+
+        verify(mock).withClosure(anyClosure())
+        verify(mock).withClosureReturningVoid(anyClosure())
+        verify(mock).withClosureReturningInt(anyClosure())
+        verify(mock).withOptionalClosureAlone(anyClosure())
+        verify(mock).withNestedClosure1(anyClosure())
+        verify(mock).withNestedClosure2(anyNestedClosure())
+    }
+
+    func testWithEscape() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withEscape(anyString(), action: anyClosure())).then { text, closure in closure(text) }
+        }
+
+        mock.withEscape("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withEscape(anyString(), action: anyClosure())
+    }
+
+    func testWithOptionalClosure() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withOptionalClosure(anyString(), closure: anyClosure())).then { text, closure in closure?(text)  }
+        }
+
+        mock.withOptionalClosure("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withOptionalClosure(anyString(), closure: anyClosure())
+    }
+
+    func testWithLabel() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withLabelAndUnderscore(labelA: anyString(), anyString())).then { _ in called = true }
+        }
+
+        mock.withLabelAndUnderscore(labelA: "a", "b")
+        XCTAssertTrue(called)
+        verify(mock).withLabelAndUnderscore(labelA: anyString(), anyString())
+    }
+
+    func testCallingCountCharactersMethodWithHello() {
+        stub(mock) { mock in
+            when(mock.callingCountCharactersMethodWithHello()).thenCallRealImplementation()
+            when(mock.count(characters: any())).thenReturn(0)
+        }
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+        verify(mock).count(characters: "Hello")
+    }
+
+    func testDefaultImplCall() {
+        mock.enableDefaultImplementation(NestedStruct.NestedTestedSubclassStub())
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+    }
+}

--- a/Tests/Swift/NestedStructTest.swift
+++ b/Tests/Swift/NestedStructTest.swift
@@ -2,7 +2,7 @@
 //  NestedStructTest.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/NestedSubclassTests.swift
+++ b/Tests/Swift/NestedSubclassTests.swift
@@ -1,0 +1,219 @@
+//
+//  NestedSubclassTests.swift
+//  Cuckoo
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+import XCTest
+import Cuckoo
+
+class NestedSubclassTest: XCTestCase {
+
+    private var mock: Nested.MockNestedTestedSubclass!
+
+    override func setUp() {
+        super.setUp()
+
+        mock = Nested.MockNestedTestedSubclass()
+    }
+
+    func testReadOnlyProperty() {
+        let mock = Nested.MockNestedTestedSubclass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyProperty, "a")
+        verify(mock).readOnlyProperty.get()
+    }
+
+    func testReadOnlyOptionalProperty() {
+        let mock = Nested.MockNestedTestedSubclass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn("a")
+        }
+
+        XCTAssertEqual(mock.readOnlyOptionalProperty, "a")
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testOptionalReadOnlyPropertyIsNil() {
+        let mock = Nested.MockNestedTestedSubclass()
+
+        stub(mock) { mock in
+            when(mock.readOnlyOptionalProperty.get).thenReturn(nil)
+        }
+
+        XCTAssertNil(mock.readOnlyOptionalProperty)
+        verify(mock).readOnlyOptionalProperty.get()
+    }
+
+    func testReadWriteProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.readWriteProperty.get).thenReturn(1)
+            when(mock.readWriteProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.readWriteProperty = 0
+
+        XCTAssertEqual(mock.readWriteProperty, 1)
+        XCTAssertTrue(called)
+        verify(mock).readWriteProperty.get()
+        verify(mock).readWriteProperty.set(0)
+    }
+
+    func testOptionalProperty() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.optionalProperty.get).thenReturn(nil)
+            when(mock.optionalProperty.set(anyInt())).then { _ in called = true }
+        }
+
+        mock.optionalProperty = 0
+
+        XCTAssertNil(mock.optionalProperty)
+        XCTAssertTrue(called)
+        verify(mock).optionalProperty.get()
+        verify(mock).optionalProperty.set(equal(to: 0))
+    }
+
+    func testNoReturn() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.noReturn()).then { _ in called = true }
+        }
+
+        mock.noReturn()
+
+        XCTAssertTrue(called)
+        verify(mock).noReturn()
+    }
+
+    func testCountCharacters() {
+        stub(mock) { mock in
+            when(mock.count(characters: "a")).thenReturn(1)
+        }
+
+        XCTAssertEqual(mock.count(characters: "a"), 1)
+        verify(mock).count(characters: "a")
+    }
+
+    func testWithThrows() {
+        stub(mock) { mock in
+            when(mock.withThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            _ = try mock.withThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withThrows()
+    }
+
+    func testWithNoReturnThrows() {
+        stub(mock) { mock in
+            when(mock.withNoReturnThrows()).thenThrow(TestError.unknown)
+        }
+
+        var catched = false
+        do {
+            try mock.withNoReturnThrows()
+        } catch {
+            catched = true
+        }
+
+        XCTAssertTrue(catched)
+        verify(mock).withNoReturnThrows()
+    }
+
+    func testWithClosure() {
+        func anyNestedClosure<IN1, IN2, OUT>() -> ParameterMatcher<((IN1) -> IN2) -> OUT> {
+            return ParameterMatcher()
+        }
+
+        stub(mock) { mock in
+            when(mock.withClosure(anyClosure())).then { $0("a") }
+            when(mock.withClosureReturningVoid(anyClosure())).then { $0("a")() }
+            when(mock.withClosureReturningInt(anyClosure())).then { $0("a")(1) }
+            when(mock.withOptionalClosureAlone(anyClosure())).then { $0?("a")(1) ?? 1 }
+            when(mock.withNestedClosure1(anyClosure())).then { $0("a")({ Int($0) ?? 1 }) }
+            when(mock.withNestedClosure2(anyNestedClosure())).then { $0({ Int($0) ?? 1 })({ Int($0) ?? 1 }) }
+        }
+
+        XCTAssertEqual(mock.withClosure { _ in 1 }, 1)
+        XCTAssertEqual(mock.withClosureReturningVoid {_ in { return 1 } }, 1)
+        XCTAssertEqual(mock.withClosureReturningInt { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withOptionalClosureAlone { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure1 { _ in { _ in return 1 } }, 1)
+        XCTAssertEqual(mock.withNestedClosure2 { _ in { _ in return 1 } }, 1)
+
+        verify(mock).withClosure(anyClosure())
+        verify(mock).withClosureReturningVoid(anyClosure())
+        verify(mock).withClosureReturningInt(anyClosure())
+        verify(mock).withOptionalClosureAlone(anyClosure())
+        verify(mock).withNestedClosure1(anyClosure())
+        verify(mock).withNestedClosure2(anyNestedClosure())
+    }
+
+    func testWithEscape() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withEscape(anyString(), action: anyClosure())).then { text, closure in closure(text) }
+        }
+
+        mock.withEscape("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withEscape(anyString(), action: anyClosure())
+    }
+
+    func testWithOptionalClosure() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withOptionalClosure(anyString(), closure: anyClosure())).then { text, closure in closure?(text)  }
+        }
+
+        mock.withOptionalClosure("a") { called = $0 == "a" }
+
+        XCTAssertTrue(called)
+        verify(mock).withOptionalClosure(anyString(), closure: anyClosure())
+    }
+
+    func testWithLabel() {
+        var called = false
+        stub(mock) { mock in
+            when(mock.withLabelAndUnderscore(labelA: anyString(), anyString())).then { _ in called = true }
+        }
+
+        mock.withLabelAndUnderscore(labelA: "a", "b")
+        XCTAssertTrue(called)
+        verify(mock).withLabelAndUnderscore(labelA: anyString(), anyString())
+    }
+
+    func testCallingCountCharactersMethodWithHello() {
+        stub(mock) { mock in
+            when(mock.callingCountCharactersMethodWithHello()).thenCallRealImplementation()
+            when(mock.count(characters: any())).thenReturn(0)
+        }
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+        verify(mock).count(characters: "Hello")
+    }
+
+    func testDefaultImplCall() {
+        mock.enableDefaultImplementation(Nested.NestedTestedSubclassStub())
+
+        XCTAssertEqual(mock.callingCountCharactersMethodWithHello(), 0)
+        verify(mock).callingCountCharactersMethodWithHello()
+    }
+}

--- a/Tests/Swift/NestedSubclassTests.swift
+++ b/Tests/Swift/NestedSubclassTests.swift
@@ -2,7 +2,7 @@
 //  NestedSubclassTests.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/Source/MultiNestedInExtensionFromClass.swift
+++ b/Tests/Swift/Source/MultiNestedInExtensionFromClass.swift
@@ -2,7 +2,7 @@
 //  MultiNestedInExtensionFromClass.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/Source/MultiNestedInExtensionFromClass.swift
+++ b/Tests/Swift/Source/MultiNestedInExtensionFromClass.swift
@@ -1,0 +1,105 @@
+////
+////  MultiNestedInExtensionFromClass.swift
+////  Cuckoo
+////
+////  Created by thompsty on 9/18/20.
+////
+//
+//import Foundation
+//extension Multi.Nested {
+//    @available(swift 4.0)
+//    class NestedExtensionTestedClass {
+//
+//        let constant: Float = 0.0
+//
+//        private(set) var privateSetProperty: Int = 0
+//
+//        var readOnlyProperty: String {
+//            return "a"
+//        }
+//
+//        var readOnlyOptionalProperty: String? {
+//            return "a"
+//        }
+//
+//        @available(iOS 42.0, *)
+//        var unavailableProperty: UnavailableProtocol? {
+//            return nil
+//        }
+//
+//        lazy var readWriteProperty: Int = 0
+//
+//        lazy var optionalProperty: Int? = 0
+//
+//        func noReturn() {
+//        }
+//
+//        func count(characters: String) -> Int {
+//            return characters.count
+//        }
+//
+//        func withThrows() throws -> Int {
+//            return 0
+//        }
+//
+//        func withNoReturnThrows() throws {
+//        }
+//
+//        func withClosure(_ closure: (String) -> Int) -> Int {
+//            return closure("hello")
+//        }
+//
+//        func withClosureReturningVoid(_ closure: (String) -> () -> Int) -> Int {
+//            return closure("hello")()
+//        }
+//
+//        func withClosureReturningInt(_ closure: (String) -> (Int) -> Int) -> Int {
+//            return closure("hello")(3)
+//        }
+//
+//        func withOptionalClosureAlone(_ closure: ((String) -> (Int) -> Int)?) -> Int {
+//            return (closure?("hello") ?? { $0 })(3)
+//        }
+//
+//        func withNestedClosure1(_ closure: (String) -> ((String) -> Int) -> Int) -> Int {
+//            return closure("hello")({ Int($0) ?? 0 })
+//        }
+//
+//        func withNestedClosure2(_ closure: ((String) -> Int) -> ((String) -> Int) -> Int) -> Int {
+//            return closure({ Int($0) ?? 0 })({ Int($0) ?? 0 })
+//        }
+//
+//        func withEscape(_ a: String, action closure: @escaping (String) -> Void) {
+//            closure(a)
+//        }
+//
+//        func withOptionalClosure(_ a: String, closure: ((String) -> Void)?) {
+//            closure?(a)
+//        }
+//
+//        func empty(_: String) {
+//            // hello there
+//        }
+//
+//        func withLabelAndUnderscore(labelA a: String, _ b: String) {
+//        }
+//
+//        func callingCountCharactersMethodWithHello() -> Int {
+//            return count(characters: "Hello")
+//        }
+//
+//        // How to test for the absence of all these?
+//        private func thisFunctionShouldNotBeMocked1() {
+//        }
+//
+//        fileprivate func thisFunctionShouldNotBeMocked2() {
+//        }
+//
+//        private var notMocked1: Int?
+//        fileprivate var notMocked2: Int?
+//
+//        deinit {
+//
+//        }
+//    }
+//}

--- a/Tests/Swift/Source/MultiNestedInExtensionFromClass.swift
+++ b/Tests/Swift/Source/MultiNestedInExtensionFromClass.swift
@@ -1,105 +1,12 @@
-////
-////  MultiNestedInExtensionFromClass.swift
-////  Cuckoo
-////
-////  Created by thompsty on 9/18/20.
-////
 //
-//import Foundation
-//extension Multi.Nested {
-//    @available(swift 4.0)
-//    class NestedExtensionTestedClass {
+//  MultiNestedInExtensionFromClass.swift
+//  Cuckoo
 //
-//        let constant: Float = 0.0
+//  Created by thompsty on 9/18/20.
 //
-//        private(set) var privateSetProperty: Int = 0
-//
-//        var readOnlyProperty: String {
-//            return "a"
-//        }
-//
-//        var readOnlyOptionalProperty: String? {
-//            return "a"
-//        }
-//
-//        @available(iOS 42.0, *)
-//        var unavailableProperty: UnavailableProtocol? {
-//            return nil
-//        }
-//
-//        lazy var readWriteProperty: Int = 0
-//
-//        lazy var optionalProperty: Int? = 0
-//
-//        func noReturn() {
-//        }
-//
-//        func count(characters: String) -> Int {
-//            return characters.count
-//        }
-//
-//        func withThrows() throws -> Int {
-//            return 0
-//        }
-//
-//        func withNoReturnThrows() throws {
-//        }
-//
-//        func withClosure(_ closure: (String) -> Int) -> Int {
-//            return closure("hello")
-//        }
-//
-//        func withClosureReturningVoid(_ closure: (String) -> () -> Int) -> Int {
-//            return closure("hello")()
-//        }
-//
-//        func withClosureReturningInt(_ closure: (String) -> (Int) -> Int) -> Int {
-//            return closure("hello")(3)
-//        }
-//
-//        func withOptionalClosureAlone(_ closure: ((String) -> (Int) -> Int)?) -> Int {
-//            return (closure?("hello") ?? { $0 })(3)
-//        }
-//
-//        func withNestedClosure1(_ closure: (String) -> ((String) -> Int) -> Int) -> Int {
-//            return closure("hello")({ Int($0) ?? 0 })
-//        }
-//
-//        func withNestedClosure2(_ closure: ((String) -> Int) -> ((String) -> Int) -> Int) -> Int {
-//            return closure({ Int($0) ?? 0 })({ Int($0) ?? 0 })
-//        }
-//
-//        func withEscape(_ a: String, action closure: @escaping (String) -> Void) {
-//            closure(a)
-//        }
-//
-//        func withOptionalClosure(_ a: String, closure: ((String) -> Void)?) {
-//            closure?(a)
-//        }
-//
-//        func empty(_: String) {
-//            // hello there
-//        }
-//
-//        func withLabelAndUnderscore(labelA a: String, _ b: String) {
-//        }
-//
-//        func callingCountCharactersMethodWithHello() -> Int {
-//            return count(characters: "Hello")
-//        }
-//
-//        // How to test for the absence of all these?
-//        private func thisFunctionShouldNotBeMocked1() {
-//        }
-//
-//        fileprivate func thisFunctionShouldNotBeMocked2() {
-//        }
-//
-//        private var notMocked1: Int?
-//        fileprivate var notMocked2: Int?
-//
-//        deinit {
-//
-//        }
-//    }
-//}
+
+import Foundation
+extension Multi.Nested {
+    @available(swift 4.0)
+    class NestedExtensionTestedClass : TestedClass {}
+}

--- a/Tests/Swift/Source/MultiNestedInNestedClass.swift
+++ b/Tests/Swift/Source/MultiNestedInNestedClass.swift
@@ -2,7 +2,7 @@
 //  MultiNestedInNestedClass.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/Source/MultiNestedInNestedClass.swift
+++ b/Tests/Swift/Source/MultiNestedInNestedClass.swift
@@ -1,0 +1,28 @@
+//
+//  MultiNestedInNestedClass.swift
+//  Cuckoo
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+@available(swift 4.0)
+class Multi {
+    class Nested {
+        class MultiNestedTestedSubclass: TestedClass { }
+        
+        private class ThisClassShouldNotBeMocked3 {
+            var property: Int?
+        }
+    }
+    
+    class Layered {
+        class Nested {
+            class MultiLayeredNestedTestedSubclass: TestedClass { }
+            
+            private class ThisClassShouldNotBeMocked3 {
+                var property: Int?
+            }
+        }
+    }
+}

--- a/Tests/Swift/Source/MultiNestedInPrivateNestedClass.swift
+++ b/Tests/Swift/Source/MultiNestedInPrivateNestedClass.swift
@@ -2,7 +2,7 @@
 //  MultiNestedInPrivateNestedClass.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/Source/MultiNestedInPrivateNestedClass.swift
+++ b/Tests/Swift/Source/MultiNestedInPrivateNestedClass.swift
@@ -1,16 +1,16 @@
-////
-////  MultiNestedInPrivateNestedClass.swift
-////  Cuckoo
-////
-////  Created by thompsty on 9/18/20.
-////
 //
-//import Foundation
+//  MultiNestedInPrivateNestedClass.swift
+//  Cuckoo
 //
-//class MultiNestedClass {
-//    private class PrivateNestedClass {
-//        class ThisClassShouldNotBeMocked2 {
-//            var property: Int?
-//        }
-//    }
-//}
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+
+class MultiNestedClass {
+    private class PrivateNestedClass {
+        class ThisClassShouldNotBeMocked2 {
+            var property: Int?
+        }
+    }
+}

--- a/Tests/Swift/Source/MultiNestedInPrivateNestedClass.swift
+++ b/Tests/Swift/Source/MultiNestedInPrivateNestedClass.swift
@@ -1,0 +1,16 @@
+////
+////  MultiNestedInPrivateNestedClass.swift
+////  Cuckoo
+////
+////  Created by thompsty on 9/18/20.
+////
+//
+//import Foundation
+//
+//class MultiNestedClass {
+//    private class PrivateNestedClass {
+//        class ThisClassShouldNotBeMocked2 {
+//            var property: Int?
+//        }
+//    }
+//}

--- a/Tests/Swift/Source/MultiNestedPrivateExtensionClass.swift
+++ b/Tests/Swift/Source/MultiNestedPrivateExtensionClass.swift
@@ -1,0 +1,14 @@
+////
+////  MultiNestedPrivateExtensionClass.swift
+////  Cuckoo
+////
+////  Created by thompsty on 9/18/20.
+////
+//
+//import Foundation
+//
+//fileprivate extension Multi.Nested {
+//    class ThisClassShouldNotBeMocked1 {
+//        var property: Int?
+//    }
+//}

--- a/Tests/Swift/Source/MultiNestedPrivateExtensionClass.swift
+++ b/Tests/Swift/Source/MultiNestedPrivateExtensionClass.swift
@@ -2,7 +2,7 @@
 //  MultiNestedPrivateExtensionClass.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/Source/MultiNestedPrivateExtensionClass.swift
+++ b/Tests/Swift/Source/MultiNestedPrivateExtensionClass.swift
@@ -1,14 +1,14 @@
-////
-////  MultiNestedPrivateExtensionClass.swift
-////  Cuckoo
-////
-////  Created by thompsty on 9/18/20.
-////
 //
-//import Foundation
+//  MultiNestedPrivateExtensionClass.swift
+//  Cuckoo
 //
-//fileprivate extension Multi.Nested {
-//    class ThisClassShouldNotBeMocked1 {
-//        var property: Int?
-//    }
-//}
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+
+fileprivate extension Multi.Nested {
+    class ThisClassShouldNotBeMocked1 {
+        var property: Int?
+    }
+}

--- a/Tests/Swift/Source/NestedInExtensionFromClass.swift
+++ b/Tests/Swift/Source/NestedInExtensionFromClass.swift
@@ -101,4 +101,5 @@ extension Nested {
         deinit {
 
         }
-    }}
+    }
+}

--- a/Tests/Swift/Source/NestedInExtensionFromClass.swift
+++ b/Tests/Swift/Source/NestedInExtensionFromClass.swift
@@ -1,0 +1,104 @@
+//
+//  NestedInExtensionFromClass.swift
+//  Cuckoo
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+extension Nested {
+    @available(swift 4.0)
+    class NestedExtensionTestedClass {
+
+        let constant: Float = 0.0
+
+        private(set) var privateSetProperty: Int = 0
+
+        var readOnlyProperty: String {
+            return "a"
+        }
+
+        var readOnlyOptionalProperty: String? {
+            return "a"
+        }
+
+        @available(iOS 42.0, *)
+        var unavailableProperty: UnavailableProtocol? {
+            return nil
+        }
+
+        lazy var readWriteProperty: Int = 0
+
+        lazy var optionalProperty: Int? = 0
+
+        func noReturn() {
+        }
+
+        func count(characters: String) -> Int {
+            return characters.count
+        }
+
+        func withThrows() throws -> Int {
+            return 0
+        }
+
+        func withNoReturnThrows() throws {
+        }
+
+        func withClosure(_ closure: (String) -> Int) -> Int {
+            return closure("hello")
+        }
+
+        func withClosureReturningVoid(_ closure: (String) -> () -> Int) -> Int {
+            return closure("hello")()
+        }
+
+        func withClosureReturningInt(_ closure: (String) -> (Int) -> Int) -> Int {
+            return closure("hello")(3)
+        }
+
+        func withOptionalClosureAlone(_ closure: ((String) -> (Int) -> Int)?) -> Int {
+            return (closure?("hello") ?? { $0 })(3)
+        }
+
+        func withNestedClosure1(_ closure: (String) -> ((String) -> Int) -> Int) -> Int {
+            return closure("hello")({ Int($0) ?? 0 })
+        }
+
+        func withNestedClosure2(_ closure: ((String) -> Int) -> ((String) -> Int) -> Int) -> Int {
+            return closure({ Int($0) ?? 0 })({ Int($0) ?? 0 })
+        }
+
+        func withEscape(_ a: String, action closure: @escaping (String) -> Void) {
+            closure(a)
+        }
+
+        func withOptionalClosure(_ a: String, closure: ((String) -> Void)?) {
+            closure?(a)
+        }
+
+        func empty(_: String) {
+            // hello there
+        }
+
+        func withLabelAndUnderscore(labelA a: String, _ b: String) {
+        }
+
+        func callingCountCharactersMethodWithHello() -> Int {
+            return count(characters: "Hello")
+        }
+
+        // How to test for the absence of all these?
+        private func thisFunctionShouldNotBeMocked1() {
+        }
+
+        fileprivate func thisFunctionShouldNotBeMocked2() {
+        }
+
+        private var notMocked1: Int?
+        fileprivate var notMocked2: Int?
+
+        deinit {
+
+        }
+    }}

--- a/Tests/Swift/Source/NestedInExtensionFromClass.swift
+++ b/Tests/Swift/Source/NestedInExtensionFromClass.swift
@@ -2,7 +2,7 @@
 //  NestedInExtensionFromClass.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/Source/NestedInNestedClass.swift
+++ b/Tests/Swift/Source/NestedInNestedClass.swift
@@ -10,6 +10,10 @@ import Foundation
 class Nested {
     class NestedTestedSubclass: TestedClass { }
     
+    private class ThisClassShouldNotBeMocked3 {
+        var property: Int?
+    }
+    
     class NestedTestedClass {
 
         let constant: Float = 0.0

--- a/Tests/Swift/Source/NestedInNestedClass.swift
+++ b/Tests/Swift/Source/NestedInNestedClass.swift
@@ -2,7 +2,7 @@
 //  NestedInNestedClass.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/Source/NestedInNestedClass.swift
+++ b/Tests/Swift/Source/NestedInNestedClass.swift
@@ -8,6 +8,8 @@
 import Foundation
 @available(swift 4.0)
 class Nested {
+    class NestedTestedSubclass: TestedClass { }
+    
     class NestedTestedClass {
 
         let constant: Float = 0.0

--- a/Tests/Swift/Source/NestedInNestedClass.swift
+++ b/Tests/Swift/Source/NestedInNestedClass.swift
@@ -1,0 +1,105 @@
+//
+//  NestedInNestedClass.swift
+//  Cuckoo
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+@available(swift 4.0)
+class Nested {
+    class NestedTestedClass {
+
+        let constant: Float = 0.0
+
+        private(set) var privateSetProperty: Int = 0
+
+        var readOnlyProperty: String {
+            return "a"
+        }
+
+        var readOnlyOptionalProperty: String? {
+            return "a"
+        }
+
+        @available(iOS 42.0, *)
+        var unavailableProperty: UnavailableProtocol? {
+            return nil
+        }
+
+        lazy var readWriteProperty: Int = 0
+
+        lazy var optionalProperty: Int? = 0
+
+        func noReturn() {
+        }
+
+        func count(characters: String) -> Int {
+            return characters.count
+        }
+
+        func withThrows() throws -> Int {
+            return 0
+        }
+
+        func withNoReturnThrows() throws {
+        }
+
+        func withClosure(_ closure: (String) -> Int) -> Int {
+            return closure("hello")
+        }
+
+        func withClosureReturningVoid(_ closure: (String) -> () -> Int) -> Int {
+            return closure("hello")()
+        }
+
+        func withClosureReturningInt(_ closure: (String) -> (Int) -> Int) -> Int {
+            return closure("hello")(3)
+        }
+
+        func withOptionalClosureAlone(_ closure: ((String) -> (Int) -> Int)?) -> Int {
+            return (closure?("hello") ?? { $0 })(3)
+        }
+
+        func withNestedClosure1(_ closure: (String) -> ((String) -> Int) -> Int) -> Int {
+            return closure("hello")({ Int($0) ?? 0 })
+        }
+
+        func withNestedClosure2(_ closure: ((String) -> Int) -> ((String) -> Int) -> Int) -> Int {
+            return closure({ Int($0) ?? 0 })({ Int($0) ?? 0 })
+        }
+
+        func withEscape(_ a: String, action closure: @escaping (String) -> Void) {
+            closure(a)
+        }
+
+        func withOptionalClosure(_ a: String, closure: ((String) -> Void)?) {
+            closure?(a)
+        }
+
+        func empty(_: String) {
+            // hello there
+        }
+
+        func withLabelAndUnderscore(labelA a: String, _ b: String) {
+        }
+
+        func callingCountCharactersMethodWithHello() -> Int {
+            return count(characters: "Hello")
+        }
+
+        // How to test for the absence of all these?
+        private func thisFunctionShouldNotBeMocked1() {
+        }
+
+        fileprivate func thisFunctionShouldNotBeMocked2() {
+        }
+
+        private var notMocked1: Int?
+        fileprivate var notMocked2: Int?
+
+        deinit {
+
+        }
+    }
+}

--- a/Tests/Swift/Source/NestedInNestedStruct.swift
+++ b/Tests/Swift/Source/NestedInNestedStruct.swift
@@ -2,7 +2,7 @@
 //  NestedInNestedStruct.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/Source/NestedInNestedStruct.swift
+++ b/Tests/Swift/Source/NestedInNestedStruct.swift
@@ -1,0 +1,16 @@
+//
+//  NestedInNestedStruct.swift
+//  Cuckoo
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+
+struct NestedStruct {
+    class NestedTestedSubclass: TestedClass { }
+}
+
+extension NestedStruct {
+    class NestedExtensionTestedClass: TestedClass { }
+}

--- a/Tests/Swift/Source/NestedInPrivateNestedClass.swift
+++ b/Tests/Swift/Source/NestedInPrivateNestedClass.swift
@@ -1,0 +1,14 @@
+//
+//  NestedInPrivateNestedClass.swift
+//  Cuckoo
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+
+fileprivate class PrivateNestedClass {
+    class ThisClassShouldNotBeMocked2 {
+        var property: Int?
+    }
+}

--- a/Tests/Swift/Source/NestedInPrivateNestedClass.swift
+++ b/Tests/Swift/Source/NestedInPrivateNestedClass.swift
@@ -2,7 +2,7 @@
 //  NestedInPrivateNestedClass.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/Source/NestedPrivateExtensionClass.swift
+++ b/Tests/Swift/Source/NestedPrivateExtensionClass.swift
@@ -2,7 +2,7 @@
 //  NestedPrivateExtensionClass.swift
 //  Cuckoo
 //
-//  Created by thompsty on 9/18/20.
+//  Created by Tyler Thompson on 9/18/20.
 //
 
 import Foundation

--- a/Tests/Swift/Source/NestedPrivateExtensionClass.swift
+++ b/Tests/Swift/Source/NestedPrivateExtensionClass.swift
@@ -1,0 +1,14 @@
+//
+//  NestedPrivateExtensionClass.swift
+//  Cuckoo
+//
+//  Created by thompsty on 9/18/20.
+//
+
+import Foundation
+
+fileprivate extension Nested {
+    class ThisClassShouldNotBeMocked1 {
+        var property: Int?
+    }
+}


### PR DESCRIPTION
#159 called for supporting nested classes for namespacing. I too, deeply desired this feature so I spent a few hours getting it in place. The implementation code didn't require a lot of tweaking, it was pretty straightforward. The testing effort was a little dramatic, because there were lots of permutations of things to test. 

To pull this off I introduced a hierarchical concept, "Parent" tokens and "Child" tokens. This is my first contribution to Cuckoo so please forgive any naming/style violations. I tried to make it feel like the rest of the codebase.