### PR TITLE
Cuckoo linking fails due to now-missing libswiftXCTest.

### DIFF
--- a/Cuckoo.podspec
+++ b/Cuckoo.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig         = {
     'ENABLE_BITCODE' => 'NO',
     'SWIFT_REFLECTION_METADATA_LEVEL' => 'none',
-    'OTHER_LDFLAGS' => '$(inherited) -weak-lswiftXCTest',
+    'OTHER_LDFLAGS' => '$(inherited) -weak-lXCTestSwiftSupport',
   }
   s.default_subspec             = 'Swift'
 


### PR DESCRIPTION
If you try to compile any project using Cuckoo in the latest version of Xcode (12.5) you won't be able to succeed as the linking phase will fail with this error: `library not found for -lswiftXCTest`.

This is a known scenario as the [Release Notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-12_5-beta-release-notes/) have the following text:

```
Xcode no longer includes XCTest’s legacy Swift overlay library (libswiftXCTest.dylib). 
Use the library’s replacement, libXCTestSwiftSupport.dylib, instead.
```