### PR TITLE
Fixed compilation of conditional imports using #if.

### DIFF
--- a/Generator/Source/CuckooGeneratorFramework/FileHeaderHandler.swift
+++ b/Generator/Source/CuckooGeneratorFramework/FileHeaderHandler.swift
@@ -57,7 +57,7 @@ public struct FileHeaderHandler {
             case .component(let componentType, let library, let name):
                 guard let componentType = componentType else {
                     let importee = Import.Importee.library(name: library)
-                    return importGenerator()(importee)
+                    return importCreator()(importee)
                 }
 
                 return """


### PR DESCRIPTION
Closes #398

> We have a framework that has a build condition `SWIFT_ACTIVE_COMPILATION_CONDITIONS = APPEXTENSION;` And based on that condition, we are importing the following libraries.
> 
> ```swift
> #if APPEXTENSION
> import CustomAppExtension
> #else
> import Custom
> #endif
> ```
> 
> The problem we are facing is that the generated mocks do not have this #if statement. They import both libraries (which causes a build fail) like below:
> 
> ```swift
> import CustomAppExtension
> import Custom
> ```
> 
> Instead, we would require the imports to happen as in the original file:
> 
> ```swift
> #if APPEXTENSION
> import CustomAppExtension
> #else
> import Custom
> #endif
> ```
> 
> Would it be possible to update Cuckoo to recognize that #if block?

My solution is to check the possibility to import framework:

```
#if canImport(CustomAppExtension)
import CustomAppExtension
#endif

#if canImport(Custom)
import Custom
#endif
```


This fix works when the single framework is embedded into the target.