### PR TITLE
Add support for concurrency mocking

### DIFF
--- a/Generator/Source/CuckooGeneratorFramework/Generator.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Generator.swift
@@ -112,6 +112,7 @@ public struct Generator {
             if parameter.isClosure && !parameter.isEscaping {
                 let indents = String(repeating: "\t", count: index)
                 let tries = method.isThrowing ? "try " : ""
+                let awaits = method.isAsync ? "await " : ""
 
                 let sugarizedReturnType = method.returnType.sugarized
                 let returnSignature: String
@@ -121,7 +122,7 @@ public struct Generator {
                     returnSignature = " -> \(sugarizedReturnType)"
                 }
 
-                fullString += "\(indents)return \(tries)withoutActuallyEscaping(\(parameter.name), do: { (\(parameter.name): @escaping \(parameter.type))\(returnSignature) in\n"
+                fullString += "\(indents)return \(tries)\(awaits)withoutActuallyEscaping(\(parameter.name), do: { (\(parameter.name): @escaping \(parameter.type))\(returnSignature) in\n"
             }
         }
 

--- a/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
@@ -104,16 +104,16 @@ extension Templates {
     {% endfor %}
     {{ method.accessibility }}{% if container.isImplementation and method.isOverriding %} override{% endif %} func {{ method.name }}{{ method.genericParameters }}({{ method.parameterSignature }}) {{ method.returnSignature }} {
         {{ method.self|openNestedClosure }}
-    return{% if method.isThrowing %} try{% endif %} cuckoo_manager.call{% if method.isThrowing %}{{ method.throwType|capitalize }}{% endif %}("{{method.fullyQualifiedName}}",
+    return{% if method.isThrowing %} try{% endif %}{% if method.isAsync %} await{% endif %} cuckoo_manager.call{% if method.isThrowing %}{{ method.throwType|capitalize }}{% endif %}("{{method.fullyQualifiedName}}",
             parameters: ({{method.parameterNames}}),
             escapingParameters: ({{method.escapingParameterNames}}),
             superclassCall:
                 {% if container.isImplementation %}
-                super.{{method.name}}({{method.call}})
+                {% if method.isAsync %}await {% endif %}super.{{method.name}}({{method.call}})
                 {% else %}
-                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                {% if method.isAsync %}await {% endif %}Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                 {% endif %},
-            defaultCall: __defaultImplStub!.{{method.name}}{%if method.isOptional %}!{%endif%}({{method.call}}))
+            defaultCall: {% if method.isAsync %}await {% endif %}__defaultImplStub!.{{method.name}}{%if method.isOptional %}!{%endif%}({{method.call}}))
         {{ method.parameters|closeNestedClosure }}
     }
     {% endfor %}

--- a/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
@@ -8,7 +8,10 @@
 extension Templates {
     static let noImplStub = """
 {{container.accessibility}} class {{ container.name }}Stub{{ container.genericParameters }}: {{ container.name }}{% if container.isImplementation %}{{ container.genericArguments }}{% endif %} {
-    {% for property in container.properties %}
+    {% for property in container.properties %}    
+    {% if debug %}
+    // {{property}}
+    {% endif %}
     {% for attribute in property.attributes %}
     {{ attribute.text }}
     {% endfor %}
@@ -31,6 +34,12 @@ extension Templates {
     {% endfor %}
 
     {% for method in container.methods %}
+    {% if debug %}
+    // {{method}}
+    {% endif %}
+    {% for attribute in method.attributes %}
+    {{ attribute.text }}
+    {% endfor %}
     {{ method.accessibility }}{% if container.@type == "ClassDeclaration" and method.isOverriding %} override{% endif %} func {{ method.name }}{{ method.genericParameters }}({{ method.parameterSignature }}) {{ method.returnSignature }} {{ method.whereClause }} {
         return DefaultValueRegistry.defaultValue(for: ({{method.returnType|genericSafe}}).self)
     }

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -443,6 +443,7 @@ public struct Tokenizer {
     /// - parameter source: A trimmed string containing only the method return signature excluding the trailing brace
     /// - returns: ReturnSignature structure containing the parsed throwString, return type, and where constraints
     private func parseReturnSignature(source: String) -> ReturnSignature {
+        var isAsync = false
         var throwString = nil as String?
         var returnType: WrappableType?
         var whereConstraints = [] as [String]
@@ -451,6 +452,11 @@ public struct Tokenizer {
         parseLoop: while index != source.endIndex {
             let character = source[index]
             switch character {
+            case "a":
+                isAsync = true
+                let asyncString = "async"
+                index = source.index(index, offsetBy: asyncString.count)
+                continue
             case "r" where returnType == nil:
                 throwString = "rethrows"
                 index = source.index(index, offsetBy: throwString!.count)
@@ -476,7 +482,7 @@ public struct Tokenizer {
             index = source.index(after: index)
         }
 
-        return ReturnSignature(throwString: throwString, returnType: returnType ?? WrappableType.type("Void"), whereConstraints: whereConstraints)
+        return ReturnSignature(isAsync: isAsync, throwString: throwString, returnType: returnType ?? WrappableType.type("Void"), whereConstraints: whereConstraints)
     }
 
     // FIXME: Remove when SourceKitten fixes the off-by-one error that includes the ending `>` in the last inherited type.

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/Method.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/Method.swift
@@ -47,7 +47,11 @@ public extension Method {
             .map { $0 + ": " + $1 }
             .joined(separator: ", ") + lastNamePart + returnSignatureString
     }
-
+    
+    var isAsync: Bool {
+        return returnSignature.isAsync
+    }
+    
     var isThrowing: Bool {
         guard let throwType = returnSignature.throwType else { return false }
         return throwType.isThrowing || throwType.isRethrowing
@@ -117,6 +121,7 @@ public extension Method {
             "escapingParameterNames": escapingParameterNames,
             "isInit": isInit,
             "returnType": returnType.explicitOptionalOnly.sugarized,
+            "isAsync": isAsync,
             "isThrowing": isThrowing,
             "throwType": returnSignature.throwType?.description ?? "",
             "fullyQualifiedName": fullyQualifiedName,

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ReturnSignature.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ReturnSignature.swift
@@ -8,11 +8,13 @@
 import Foundation
 
 public struct ReturnSignature {
+    public var isAsync: Bool
     public var throwType: ThrowType?
     public var returnType: WrappableType
     public var whereConstraints: [String]
 
-    public init(throwString: String?, returnType: WrappableType, whereConstraints: [String]) {
+    public init(isAsync: Bool, throwString: String?, returnType: WrappableType, whereConstraints: [String]) {
+        self.isAsync = isAsync
         if let throwString = throwString {
             throwType = ThrowType(string: throwString)
         } else {
@@ -25,9 +27,10 @@ public struct ReturnSignature {
 
 extension ReturnSignature: CustomStringConvertible {
     public var description: String {
+        let asyncString = isAsync ? "async" : nil
         let trimmedReturnType = returnType.explicitOptionalOnly.sugarized.trimmed
         let returnString = trimmedReturnType.isEmpty || trimmedReturnType == "Void" ? nil : "-> \(returnType)"
         let whereString = whereConstraints.isEmpty ? nil : "where \(whereConstraints.joined(separator: ", "))"
-        return [throwType?.description, returnString, whereString].compactMap { $0 }.joined(separator: " ")
+        return [asyncString, throwType?.description, returnString, whereString].compactMap { $0 }.joined(separator: " ")
     }
 }

--- a/Source/Matching/ParameterMatcherFunctions.swift
+++ b/Source/Matching/ParameterMatcherFunctions.swift
@@ -129,6 +129,102 @@ public func anyClosure<IN1, IN2, IN3, IN4, IN5, IN6, IN7, OUT>() -> ParameterMat
     return ParameterMatcher()
 }
 
+/// Returns a matcher matching any throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyThrowingClosure<OUT>() -> ParameterMatcher<() async throws -> OUT> {
+    return ParameterMatcher()
+}
+
+/// Returns a matcher matching any throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyThrowingClosure<IN1, OUT>() -> ParameterMatcher<(IN1) async throws -> OUT> {
+    return ParameterMatcher()
+}
+
+/// Returns a matcher matching any throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyThrowingClosure<IN1, IN2, OUT>() -> ParameterMatcher<(IN1, IN2) async throws -> OUT> {
+    return ParameterMatcher()
+}
+
+/// Returns a matcher matching any throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyThrowingClosure<IN1, IN2, IN3, OUT>() -> ParameterMatcher<(IN1, IN2, IN3) async throws -> OUT> {
+    return ParameterMatcher()
+}
+
+/// Returns a matcher matching any throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyThrowingClosure<IN1, IN2, IN3, IN4, OUT>() -> ParameterMatcher<(IN1, IN2, IN3, IN4) async throws -> OUT> {
+    return ParameterMatcher()
+}
+
+/// Returns a matcher matching any throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyThrowingClosure<IN1, IN2, IN3, IN4, IN5, OUT>() -> ParameterMatcher<(IN1, IN2, IN3, IN4, IN5) async throws -> OUT> {
+    return ParameterMatcher()
+}
+
+/// Returns a matcher matching any throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyThrowingClosure<IN1, IN2, IN3, IN4, IN5, IN6, OUT>() -> ParameterMatcher<(IN1, IN2, IN3, IN4, IN5, IN6) async throws -> OUT> {
+    return ParameterMatcher()
+}
+
+/// Returns a matcher matching any throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyThrowingClosure<IN1, IN2, IN3, IN4, IN5, IN6, IN7, OUT>() -> ParameterMatcher<(IN1, IN2, IN3, IN4, IN5, IN6, IN7) async throws -> OUT> {
+    return ParameterMatcher()
+}
+
+/// Returns a matcher matching any non-throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyClosure<OUT>() -> ParameterMatcher<() async -> OUT> {
+    return ParameterMatcher()
+}
+
+/// Returns a matcher matching any non-throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyClosure<IN1, OUT>() -> ParameterMatcher<(IN1) async -> OUT> {
+    return ParameterMatcher()
+}
+
+/// Returns a matcher matching any non-throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyClosure<IN1, IN2, OUT>() -> ParameterMatcher<(IN1, IN2) async -> OUT> {
+    return ParameterMatcher()
+}
+
+/// Returns a matcher matching any non-throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyClosure<IN1, IN2, IN3, OUT>() -> ParameterMatcher<(IN1, IN2, IN3) async -> OUT> {
+    return ParameterMatcher()
+}
+
+/// Returns a matcher matching any non-throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyClosure<IN1, IN2, IN3, IN4, OUT>() -> ParameterMatcher<(IN1, IN2, IN3, IN4) async -> OUT> {
+    return ParameterMatcher()
+}
+
+/// Returns a matcher matching any non-throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyClosure<IN1, IN2, IN3, IN4, IN5, OUT>() -> ParameterMatcher<(IN1, IN2, IN3, IN4, IN5) async -> OUT> {
+    return ParameterMatcher()
+}
+
+/// Returns a matcher matching any non-throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyClosure<IN1, IN2, IN3, IN4, IN5, IN6, OUT>() -> ParameterMatcher<(IN1, IN2, IN3, IN4, IN5, IN6) async -> OUT> {
+    return ParameterMatcher()
+}
+
+/// Returns a matcher matching any non-throwing closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyClosure<IN1, IN2, IN3, IN4, IN5, IN6, IN7, OUT>() -> ParameterMatcher<(IN1, IN2, IN3, IN4, IN5, IN6, IN7) async -> OUT> {
+    return ParameterMatcher()
+}
+
 /// Returns a matcher matching any T value or nil.
 public func any<T>(_ type: T.Type = T.self) -> ParameterMatcher<T> {
     return ParameterMatcher()
@@ -179,6 +275,12 @@ public func anyString() -> ParameterMatcher<String?> {
 
 /// Returns a matcher matching any closure.
 public func anyClosure<IN, OUT>() -> ParameterMatcher<(((IN)) -> OUT)?> {
+    return notNil()
+}
+
+/// Returns a matcher matching any closure.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public func anyClosure<IN, OUT>() -> ParameterMatcher<(((IN)) async -> OUT)?> {
     return notNil()
 }
 

--- a/Tests/Swift/Source/TestedClass.swift
+++ b/Tests/Swift/Source/TestedClass.swift
@@ -42,6 +42,25 @@ class TestedClass {
     func count(characters: String) -> Int {
         return characters.count
     }
+    
+    @available(iOS 42.0, *)
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func withAsync() async -> Int {
+        return 0
+    }
+    
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func withNoReturnAsync() async {
+    }
+    
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func withAsyncThrows() async throws -> Int {
+        return 0
+    }
+    
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func withNoReturnAsyncThrows() async throws {
+    }
 
     func withThrows() throws -> Int {
         return 0

--- a/Tests/Swift/Source/TestedClass.swift
+++ b/Tests/Swift/Source/TestedClass.swift
@@ -42,8 +42,7 @@ class TestedClass {
     func count(characters: String) -> Int {
         return characters.count
     }
-    
-    @available(iOS 42.0, *)
+
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withAsync() async -> Int {
         return 0

--- a/Tests/Swift/Source/TestedClass.swift
+++ b/Tests/Swift/Source/TestedClass.swift
@@ -61,6 +61,26 @@ class TestedClass {
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func withNoReturnAsyncThrows() async throws {
     }
+    
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func withAsyncClosure(closure: (String) async -> String?) -> String? {
+        return nil
+    }
+    
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func withAsyncClosureAsync(closure: (String) async -> String?) async -> String? {
+        return nil
+    }
+    
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func withAsyncEscapingClosure(closure: @escaping (String) async -> String?) -> String? {
+        return nil
+    }
+    
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func withAsyncOptionalClosureAsync(closure: ((String) async -> String?)?) async -> String? {
+        return nil
+    }
 
     func withThrows() throws -> Int {
         return 0

--- a/Tests/Swift/Source/TestedProtocol.swift
+++ b/Tests/Swift/Source/TestedProtocol.swift
@@ -17,7 +17,7 @@ protocol TestedProtocol {
     func noReturn()
 
     func count(characters: String) -> Int
-    
+
     func withThrows() throws -> Int
 
     func withNoReturnThrows() throws

--- a/Tests/Swift/Source/TestedProtocol.swift
+++ b/Tests/Swift/Source/TestedProtocol.swift
@@ -18,18 +18,6 @@ protocol TestedProtocol {
 
     func count(characters: String) -> Int
     
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    func withAsync() async -> Int
-    
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    func withNoReturnAsync() async
-    
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    func withAsyncThrows() async throws -> Int
-    
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-    func withNoReturnAsyncThrows() async throws
-    
     func withThrows() throws -> Int
 
     func withNoReturnThrows() throws

--- a/Tests/Swift/Source/TestedProtocol.swift
+++ b/Tests/Swift/Source/TestedProtocol.swift
@@ -17,7 +17,19 @@ protocol TestedProtocol {
     func noReturn()
 
     func count(characters: String) -> Int
-
+    
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func withAsync() async -> Int
+    
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func withNoReturnAsync() async
+    
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func withAsyncThrows() async throws -> Int
+    
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func withNoReturnAsyncThrows() async throws
+    
     func withThrows() throws -> Int
 
     func withNoReturnThrows() throws

--- a/Tests/Swift/Source/TestedSubclass.swift
+++ b/Tests/Swift/Source/TestedSubclass.swift
@@ -30,7 +30,13 @@ class TestedSubclass: TestedClass, TestedProtocol {
     func withImplicitlyUnwrappedOptional(i: Int!) -> String {
         return ""
     }
-
+    
+    // Should not be conflicting in mocked class
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    override func withAsync() async -> Int {
+        return 1
+    }
+    
     // Should not be conflicting in mocked class
     override func withThrows() throws -> Int {
         return 1

--- a/Tests/Swift/Stubbing/StubbingTest.swift
+++ b/Tests/Swift/Stubbing/StubbingTest.swift
@@ -143,19 +143,35 @@ class StubbingTest: XCTestCase {
             when(stub.withNoReturnAsyncThrows()).then {
                 callNoReturnAsyncThrows = true
             }
+            when(stub.withAsyncClosure(closure: anyClosure())).thenReturn("async closure")
+            when(stub.withAsyncClosureAsync(closure: anyClosure())).thenReturn("closure async")
+            when(stub.withAsyncEscapingClosure(closure: anyClosure())).thenReturn("escaping async")
+            when(stub.withAsyncOptionalClosureAsync(closure: anyClosure())).thenReturn("optional async closure async")
         }
         
         let resultAsync = await mock.withAsync()
-        let resultAsyncThrows = try! await mock.withAsyncThrows()
-        await mock.withNoReturnAsync()
-        try! await mock.withNoReturnAsyncThrows()
         XCTAssertEqual(resultAsync, 10)
+        let resultAsyncThrows = try! await mock.withAsyncThrows()
         XCTAssertEqual(resultAsyncThrows, 11)
+        await mock.withNoReturnAsync()
         XCTAssertTrue(callNoReturnAsync)
+        try! await mock.withNoReturnAsyncThrows()
         XCTAssertTrue(callNoReturnAsyncThrows)
+        XCTAssertEqual(mock.withAsyncClosure { p async in
+            return nil
+        }, "async closure")
+        let resultAsyncClosure = await mock.withAsyncClosureAsync(closure: { _ in nil })
+        XCTAssertEqual(resultAsyncClosure, "closure async")
+        XCTAssertEqual(mock.withAsyncEscapingClosure(closure: { _ in nil }), "escaping async")
+        let resultAsyncClosureAsync = await mock.withAsyncOptionalClosureAsync(closure: { _ in nil })
+        XCTAssertEqual(resultAsyncClosureAsync, "optional async closure async")
         
         verify(mock, times(1)).withAsync()
         verify(mock, times(1)).withNoReturnAsync()
+        verify(mock, times(1)).withAsyncClosure(closure: anyClosure())
+        verify(mock, times(1)).withAsyncClosureAsync(closure: anyClosure())
+        verify(mock, times(1)).withAsyncEscapingClosure(closure: anyClosure())
+        verify(mock, times(1)).withAsyncOptionalClosureAsync(closure: anyClosure())
     }
 
     func testSubclassWithGrandparentsInheritanceAcceptanceTest() {

--- a/Tests/Swift/Stubbing/StubbingTest.swift
+++ b/Tests/Swift/Stubbing/StubbingTest.swift
@@ -124,6 +124,39 @@ class StubbingTest: XCTestCase {
 
         XCTAssertEqual(mock.protocolMethod(), "a1")
     }
+    
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func testAsyncMethods() async {
+        let mock = MockTestedSubSubClass()
+
+        XCTAssertNotNil(mock)
+        
+        var callNoReturnAsync = false
+        var callNoReturnAsyncThrows = false
+        
+        stub(mock) { stub in
+            when(stub.withAsync()).thenReturn(10)
+            when(stub.withAsyncThrows()).thenReturn(11)
+            when(stub.withNoReturnAsync()).then {
+                callNoReturnAsync = true
+            }
+            when(stub.withNoReturnAsyncThrows()).then {
+                callNoReturnAsyncThrows = true
+            }
+        }
+        
+        let resultAsync = await mock.withAsync()
+        let resultAsyncThrows = try! await mock.withAsyncThrows()
+        await mock.withNoReturnAsync()
+        try! await mock.withNoReturnAsyncThrows()
+        XCTAssertEqual(resultAsync, 10)
+        XCTAssertEqual(resultAsyncThrows, 11)
+        XCTAssertTrue(callNoReturnAsync)
+        XCTAssertTrue(callNoReturnAsyncThrows)
+        
+        verify(mock, times(1)).withAsync()
+        verify(mock, times(1)).withNoReturnAsync()
+    }
 
     func testSubclassWithGrandparentsInheritanceAcceptanceTest() {
         let mock = MockTestedSubSubClass()


### PR DESCRIPTION
This PR implements support for parsing async methods and closures  as discussed in #407 