### PR TITLE
Ignore missing input files.

### DIFF
--- a/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
+++ b/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
@@ -63,7 +63,7 @@ public struct GenerateMocksCommand: CommandProtocol {
 
         do {
             if outputPath.isDirectory {
-                let inputPaths = inputFiles.map { Path($0.path!) }
+                let inputPaths = inputFiles.compactMap { $0.path }.map { Path($0) }
                 for (inputPath, outputText) in zip(inputPaths, mergedFiles) {
                     let fileName = options.filePrefix + inputPath.fileName
                     let outputFile = TextFile(path: outputPath + fileName)

--- a/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
+++ b/Generator/Source/cuckoo_generator/GenerateMocksCommand.swift
@@ -63,7 +63,7 @@ public struct GenerateMocksCommand: CommandProtocol {
 
         do {
             if outputPath.isDirectory {
-                let inputPaths = inputPathValues.map { Path($0) }
+                let inputPaths = inputFiles.map { Path($0.path!) }
                 for (inputPath, outputText) in zip(inputPaths, mergedFiles) {
                     let fileName = options.filePrefix + inputPath.fileName
                     let outputFile = TextFile(path: outputPath + fileName)


### PR DESCRIPTION
Fixes #404 

The cause of this issue is that inputPathValues that is not filtered is used to determine file name while mergedFile is filtered.

I used inputFiles as a source of inputPaths instead of inputPathValues.

Because inputFiles is filtered to ignore missing files and mergedFiles is made from inputFiles.