### PR TITLE
feat: enable OCMock's `OCMQuantifier` for `objcVerify` function. Fixes #366

### DIFF
--- a/OCMock/ObjectiveVerify.swift
+++ b/OCMock/ObjectiveVerify.swift
@@ -6,14 +6,16 @@
 //
 
 import XCTest
+import OCMock
 
 extension XCTestCase {
     /**
      * Objective-C equivalent to Cuckoo's own `verify`.
      * - parameter invocation: Autoclosured invocation of the method/variable that is being verified.
+     * - parameter quantifier: Verification to assert how many times the call was made.
      */
-    public func objcVerify<OUT>(_ invocation: @autoclosure () -> OUT, file: StaticString = #file, line: UInt = #line) {
-        OCMMacroState.beginVerifyMacro(at: OCMLocation(testCase: self, file: String(file), line: line))
+    public func objcVerify<OUT>(_ invocation: @autoclosure () -> OUT, _ quantifier: OCMQuantifier = .exactly(1), file: StaticString = #file, line: UInt = #line) {
+        OCMMacroState.beginVerifyMacro(at: OCMLocation(testCase: self, file: String(file), line: line), with: quantifier)
         _ = invocation()
         OCMMacroState.endVerifyMacro()
     }


### PR DESCRIPTION
Added support for `OCMQuantifier` to `objcVerify` function.

This PR fixes #366