### PR TITLE
Print method name using multiline string

### DIFF
--- a/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
@@ -104,7 +104,9 @@ extension Templates {
     {% endfor %}
     {{ method.accessibility }}{% if container.isImplementation and method.isOverriding %} override{% endif %} func {{ method.name }}{{ method.genericParameters }}({{ method.parameterSignature }}) {{ method.returnSignature }} {
         {{ method.self|openNestedClosure }}
-    return{% if method.isThrowing %} try{% endif %}{% if method.isAsync %} await{% endif %} cuckoo_manager.call{% if method.isThrowing %}{{ method.throwType|capitalize }}{% endif %}("{{method.fullyQualifiedName}}",
+    return{% if method.isThrowing %} try{% endif %}{% if method.isAsync %} await{% endif %} cuckoo_manager.call{% if method.isThrowing %}{{ method.throwType|capitalize }}{% endif %}(\"\"\"
+    {{method.fullyQualifiedName}}
+    \"\"\",
             parameters: ({{method.parameterNames}}),
             escapingParameters: ({{method.escapingParameterNames}}),
             superclassCall:

--- a/Generator/Source/CuckooGeneratorFramework/Templates/StubbingProxyTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/StubbingProxyTemplate.swift
@@ -26,7 +26,9 @@ extension Templates {
     {% for method in container.methods %}
     func {{method.name}}{{method.self|matchableGenericNames}}({{method.parameters|matchableParameterSignature}}) -> {{method.stubFunction}}<({{method.inputTypes|genericSafe}}){%if method.returnType != "Void" %}, {{method.returnType|genericSafe}}{%endif%}>{{method.self|matchableGenericWhereClause}} {
         {{method.parameters|parameterMatchers}}
-        return .init(stub: cuckoo_manager.createStub(for: {{ container.mockName }}.self, method: "{{method.fullyQualifiedName}}", parameterMatchers: matchers))
+        return .init(stub: cuckoo_manager.createStub(for: {{ container.mockName }}.self, method: \"\"\"
+{{method.fullyQualifiedName}}
+\"\"\", parameterMatchers: matchers))
     }
     {% endfor %}
 }

--- a/Generator/Source/CuckooGeneratorFramework/Templates/VerificationProxyTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/VerificationProxyTemplate.swift
@@ -33,7 +33,9 @@ extension Templates {
     @discardableResult
     func {{method.name}}{{method.self|matchableGenericNames}}({{method.parameters|matchableParameterSignature}}) -> Cuckoo.__DoNotUse<({{method.inputTypes|genericSafe}}), {{method.returnType|genericSafe}}>{{method.self|matchableGenericWhereClause}} {
         {{method.parameters|parameterMatchers}}
-        return cuckoo_manager.verify("{{method.fullyQualifiedName}}", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
+        return cuckoo_manager.verify(\"\"\"
+{{method.fullyQualifiedName}}
+\"\"\", callMatcher: callMatcher, parameterMatchers: matchers, sourceLocation: sourceLocation)
     }
     {% endfor %}
 }


### PR DESCRIPTION
### Summary

I printed method name using multiline string to fix this issue(#419).

### Problem

Closure parameter separated into multi line had been printed without any transformation.

This led to compilation error like this:

```swift
"foo(completion: @escaping (
            _ bar: Int,
            _ baz: Int,
            _ qux: Int
        ) -> Void)"
```

My solution is to use multiline string liike this:
```swift
"""
    foo(completion: @escaping (
            _ bar: Int,
            _ baz: Int,
            _ qux: Int
        ) -> Void)
    """
```

Thank you for your confirmation.