### PR TITLE
Fix missing attribute handling in generator for Stubs

### DIFF
--- a/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
@@ -7,6 +7,9 @@
 
 extension Templates {
     static let noImplStub = """
+{% for attribute in container.attributes %}
+{{ attribute.text }}
+{% endfor %}
 {{container.accessibility}} class {{ container.name }}Stub{{ container.genericParameters }}: {{ container.name }}{% if container.isImplementation %}{{ container.genericArguments }}{% endif %} {
     {% for property in container.properties %}
     {{ property.unavailablePlatformsCheck }}


### PR DESCRIPTION
## Problem
This PR fixes missing attributes on `*Stub` types.

This is crucial in case of higher platform requirements, especially when some properties have types available only on those required higher platforms.

Example type to mock:
```swift
import AVFoundation

@available(iOS 15.0, tvOS 15.0, *)
protocol TestedProtocol {
    var reason: AVCoordinatedPlaybackSuspension.Reason { get }
}
```

Generated mock before this PR's changes:
This fails to compile with error:
> error: 'TestedProtocol' is only available in iOS 15.0 or newer
```swift
// ... redacted

 class TestedProtocolStub: TestedProtocol {
    
    
    
    
     var reason: AVCoordinatedPlaybackSuspension.Reason {
        get {
            return DefaultValueRegistry.defaultValue(for: (AVCoordinatedPlaybackSuspension.Reason).self)
        }
        
    }
    
    

    

    
}
```

Generated mock after this PRs changes:
```swift
// ... redacted

@available(iOS 15.0, tvOS 15.0, *)

 class TestedProtocolStub: TestedProtocol {
    
    
    
    
     var reason: AVCoordinatedPlaybackSuspension.Reason {
        get {
            return DefaultValueRegistry.defaultValue(for: (AVCoordinatedPlaybackSuspension.Reason).self)
        }
        
    }
    
    

    

    
}
```