### PR TITLE
Remove unnecessary await expression in MockTemplate

### DIFF
--- a/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
@@ -131,7 +131,7 @@ extension {{ container.parentFullyQualifiedName }} {
                 {% if container.isImplementation %}
                 {% if method.isAsync %}await {% endif %}super.{{method.name}}({{method.call}})
                 {% else %}
-                {% if method.isAsync %}await {% endif %}Cuckoo.MockManager.crashOnProtocolSuperclassCall()
+                Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                 {% endif %},
             defaultCall: {% if method.isAsync %}await {% endif %}__defaultImplStub!.{{method.name}}{%if method.isOptional %}!{%endif%}({{method.call}}))
         {{ method.parameters|closeNestedClosure }}


### PR DESCRIPTION
Hi, the following warning occurred due to Swift Concurrency support.

`No 'async' operations occur within 'await' expression`

<img width="363" alt="Screen Shot 2022-08-05 at 14 18 17" src="https://user-images.githubusercontent.com/484871/183006784-a720b5d2-d7eb-4e1b-8d80-db693fbdf256.png" width="200">

I think that `crashOnProtocolSuperclassCall()` method is not an async method so I don't need an await clause.

Thanks.