### PR TITLE
Breaking change: Make OCMock's default OCMQuantifier consistent to Cuckoo's

### DIFF
--- a/OCMock/ObjectiveVerify.swift
+++ b/OCMock/ObjectiveVerify.swift
@@ -14,7 +14,7 @@ extension XCTestCase {
      * - parameter invocation: Autoclosured invocation of the method/variable that is being verified.
      * - parameter quantifier: Verification to assert how many times the call was made.
      */
-    public func objcVerify<OUT>(_ invocation: @autoclosure () -> OUT, _ quantifier: OCMQuantifier = .atLeast(1), file: StaticString = #file, line: UInt = #line) {
+    public func objcVerify<OUT>(_ invocation: @autoclosure () -> OUT, _ quantifier: OCMQuantifier = .exactly(1), file: StaticString = #file, line: UInt = #line) {
         OCMMacroState.beginVerifyMacro(at: OCMLocation(testCase: self, file: String(file), line: line), with: quantifier)
         _ = invocation()
         OCMMacroState.endVerifyMacro()

--- a/Tests/OCMock/ObjectiveClassTest.swift
+++ b/Tests/OCMock/ObjectiveClassTest.swift
@@ -158,7 +158,7 @@ class ObjectiveClassTest: XCTestCase {
         XCTAssertFalse(mock.dudka(lelo: "heya"))
         XCTAssertTrue(mock.dudka(lelo: "heyda"))
 
-        objcVerify(mock.dudka(lelo: objcAny()))
+        objcVerify(mock.dudka(lelo: objcAny()), .atLeast(1))
     }
     
     func testVerifyAtLeast() {

--- a/Tests/OCMock/ObjectiveProtocolTest.swift
+++ b/Tests/OCMock/ObjectiveProtocolTest.swift
@@ -36,9 +36,9 @@ class ObjectiveProtocolTest: XCTestCase {
 
         objcVerify(mock.tableView!(objcAny(), canFocusRowAt: IndexPath(row: 0, section: 22)))
         objcVerify(mock.tableView!(tableView, canFocusRowAt: IndexPath(row: 0, section: 22)))
-        objcVerify(mock.tableView!(objcAny(), canFocusRowAt: IndexPath(row: 1, section: 22)))
+        objcVerify(mock.tableView!(objcAny(), canFocusRowAt: IndexPath(row: 1, section: 22)), .atLeast(1))
         objcVerify(mock.tableView!(tableView, canFocusRowAt: IndexPath(row: 1, section: 22)))
-        objcVerify(mock.tableView!(objcAny(), canFocusRowAt: IndexPath(row: 1, section: 22)))
+        objcVerify(mock.tableView!(objcAny(), canFocusRowAt: IndexPath(row: 1, section: 22)), .atLeast(1))
         objcVerify(mock.tableView!(tableView, canFocusRowAt: IndexPath(row: 1, section: 22)))
     }
 
@@ -72,7 +72,7 @@ class ObjectiveProtocolTest: XCTestCase {
 
         objcVerify(mock.textField!(objcAny(), shouldChangeCharactersIn: range, replacementString: "Hello from the other side, ObjC!"))
         objcVerify(mock.textField!(objcAny(), shouldChangeCharactersIn: range, replacementString: "TadeasKriz is a HaXoR."))
-        objcVerify(mock.textField!(objcAny(), shouldChangeCharactersIn: range, replacementString: objcAny()))
+        objcVerify(mock.textField!(objcAny(), shouldChangeCharactersIn: range, replacementString: objcAny()), .atLeast(1))
     }
 
     // NOTE: This is an example of a wrong way to test an optional method.


### PR DESCRIPTION
This PR breaks the API and as such can't be released in a non-major version.