### PR TITLE
Remove closure argument name.

### DIFF
--- a/Generator/Source/CuckooGeneratorFramework/Generator.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Generator.swift
@@ -73,6 +73,11 @@ public struct Generator {
             return self.escapeReservedKeywords(for: name)
         }
 
+        ext.registerFilter("removeClosureArgumentNames") { (value: Any?) in
+            guard let type = value as? String else { return value }
+            return self.removeClosureArgumentNames(for: type)
+        }
+
         let environment = Environment(extensions: [ext])
 
         let containers = declarations.compactMap { $0 as? ContainerToken }
@@ -160,5 +165,13 @@ public struct Generator {
     
     private func escapeReservedKeywords(for name: String) -> String {
         Self.reservedKeywordsNotAllowedAsMethodName.contains(name) ? "`\(name)`" : name
+    }
+
+    private func removeClosureArgumentNames(for type: String) -> String {
+        type.replacingOccurrences(
+            of: "_\\s+?[_a-zA-Z]\\w*?\\s*?:",
+            with: "",
+            options: .regularExpression
+        )
     }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
@@ -21,7 +21,7 @@ extension Templates {
     {% endfor %}
     {{ property.accessibility }}{% if container.@type == "ClassDeclaration" %} override{% endif %} var {{ property.name }}: {{ property.type }} {
         get {
-            return DefaultValueRegistry.defaultValue(for: ({{property.type|genericSafe}}).self)
+            return DefaultValueRegistry.defaultValue(for: ({{property.type|genericSafe|removeClosureArgumentNames}}).self)
         }
         {% ifnot property.isReadOnly %}
         set { }

--- a/Tests/Swift/Source/TestedClass.swift
+++ b/Tests/Swift/Source/TestedClass.swift
@@ -38,9 +38,15 @@ class TestedClass {
 
     var closureProperty: ((String) -> Int) -> () = { i in }
 
-    var closureWithArgumentNameProperty:  (_ i_iI0: (_ j_jJ0: String) -> Int) -> () = { i in }
+    var closureWithArgumentNameProperty: (_ i: (_ j: String) -> Int) -> () = { i in }
 
     var closureWithArgumentNameMultilineProperty: (
+        _ i: (_ j: Int) -> String
+    ) -> () = { i in }
+
+    var closureWithComplexArgumentNameProperty:  (_ i_iI0: (_ j_jJ0: String) -> Int) -> () = { i in }
+
+    var closureWithComplexArgumentNameMultilineProperty: (
         _ i_iI0   : (
             _ j_jJ0
             : Int

--- a/Tests/Swift/Source/TestedClass.swift
+++ b/Tests/Swift/Source/TestedClass.swift
@@ -36,6 +36,17 @@ class TestedClass {
 
     lazy var optionalProperty: Int? = 0
 
+    var closureProperty: ((String) -> Int) -> () = { i in }
+
+    var closureWithArgumentNameProperty:  (_ i_iI0: (_ j_jJ0: String) -> Int) -> () = { i in }
+
+    var closureWithArgumentNameMultilineProperty: (
+        _ i_iI0   : (
+            _ j_jJ0
+            : Int
+        ) -> String
+    ) -> () = { i in }
+
     func noReturn() {
     }
 

--- a/Tests/Swift/Source/TestedProtocol.swift
+++ b/Tests/Swift/Source/TestedProtocol.swift
@@ -16,9 +16,18 @@ protocol TestedProtocol {
 
     var closureProperty: ((String) -> Int) -> () { get set }
 
-    var closureWithArgumentNameProperty:  (_ i_iI0: (_ j_jJ0: String) -> Int) -> () { get set }
+    var closureWithArgumentNameProperty: (_ i: (_ j: String) -> Int) -> () { get set }
 
     var closureWithArgumentNameMultilineProperty: (
+        _ i   : (
+            _ j
+            : Int
+        ) -> String
+    ) -> () { get set }
+
+    var closureWithComplexArgumentNameProperty: (_ i_iI0: (_ j_jJ0: String) -> Int) -> () { get set }
+
+    var closureWithComplexArgumentNameMultilineProperty: (
         _ i_iI0   : (
             _ j_jJ0
             : Int

--- a/Tests/Swift/Source/TestedProtocol.swift
+++ b/Tests/Swift/Source/TestedProtocol.swift
@@ -14,6 +14,17 @@ protocol TestedProtocol {
 
     var optionalProperty: Int? { get set }
 
+    var closureProperty: ((String) -> Int) -> () { get set }
+
+    var closureWithArgumentNameProperty:  (_ i_iI0: (_ j_jJ0: String) -> Int) -> () { get set }
+
+    var closureWithArgumentNameMultilineProperty: (
+        _ i_iI0   : (
+            _ j_jJ0
+            : Int
+        ) -> String
+    ) -> () { get set }
+
     func noReturn()
 
     func count(characters: String) -> Int


### PR DESCRIPTION
# Summary
I removed closure argument name to fix this issue(#394).

# Problem
Closure argument name is not allowed to be used as `Type`.

This problem caused compile error like this:

```swift
DefaultValueRegistry.defaultValue(for: ((_ uuid: CBUUID) -> ()).self)
```

- **Expected ',' separator insert ','**
- **Expected type before '->'**

# Solution
My solution is to remove argument name like this:

```swift
DefaultValueRegistry.defaultValue(for: ((CBUUID) -> ()).self)
```

Thank you for your confirmation.