### PR TITLE
Support NSObjectProtocol inheritance for protocol.

### DIFF
--- a/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/MockTemplate.swift
@@ -23,7 +23,7 @@ extension Templates {
 extension {{ container.parentFullyQualifiedName }} {
 {% endif %}
 
-{{ container.accessibility }} class {{ container.mockName }}{{ container.genericParameters }}: {{ container.name }}{% if container.isImplementation %}{{ container.genericArguments }}{% endif %}, {% if container.isImplementation %}Cuckoo.ClassMock{% else %}Cuckoo.ProtocolMock{% endif %} {
+{{ container.accessibility }} class {{ container.mockName }}{{ container.genericParameters }}: {% if container.isNSObjectProtocol %}NSObject, {% endif %}{{ container.name }}{% if container.isImplementation %}{{ container.genericArguments }}{% endif %}, {% if container.isImplementation %}Cuckoo.ClassMock{% else %}Cuckoo.ProtocolMock{% endif %} {
     {% if container.isGeneric and not container.isImplementation %}
     {{ container.accessibility }} typealias MocksType = \(typeErasureClassName){{ container.genericArguments }}
     {% else %}

--- a/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Templates/NopImplStubTemplate.swift
@@ -10,7 +10,7 @@ extension Templates {
 {% for attribute in container.attributes %}
 {{ attribute.text }}
 {% endfor %}
-{{container.accessibility}} class {{ container.name }}Stub{{ container.genericParameters }}: {{ container.name }}{% if container.isImplementation %}{{ container.genericArguments }}{% endif %} {
+{{container.accessibility}} class {{ container.name }}Stub{{ container.genericParameters }}: {% if container.isNSObjectProtocol %}NSObject, {% endif %}{{ container.name }}{% if container.isImplementation %}{{ container.genericArguments }}{% endif %} {
     {% for property in container.properties %}
     {{ property.unavailablePlatformsCheck }}
     {% if debug %}

--- a/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokenizer.swift
@@ -110,7 +110,8 @@ public struct Tokenizer {
                 children: children,
                 inheritedTypes: tokenizedInheritedTypes,
                 attributes: attributes,
-                genericParameters: fixedGenericParameters
+                genericParameters: fixedGenericParameters,
+                isNSObjectProtocol: false
             )
 
         case Kinds.ClassDeclaration.rawValue:

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ContainerToken.swift
@@ -65,6 +65,7 @@ extension ContainerToken {
             "genericParameters": isGeneric ? "<\(genericParametersString)>" : "",
             "genericArguments": isGeneric ? "<\(genericArgumentsString)>" : "",
             "genericProtocolIdentity": genericProtocolIdentity,
+            "isNSObjectProtocol": (self as? ProtocolDeclaration)?.isNSObjectProtocol ?? false
         ]
     }
 }

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/FileRepresentation.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/FileRepresentation.swift
@@ -27,6 +27,10 @@ public extension FileRepresentation {
 
         return FileRepresentation(sourceFile: self.sourceFile, declarations: tokens)
     }
+
+    func inheritNSObject(subjects: [ProtocolDeclaration]) -> FileRepresentation {
+        FileRepresentation(sourceFile: self.sourceFile, declarations: self.declarations.map { $0.inheritNSObject(subjects: subjects) })
+    }
 }
 
 extension Token {
@@ -57,6 +61,13 @@ extension Token {
         default:
             return typeToken
         }
+    }
+
+    func inheritNSObject(subjects: [ProtocolDeclaration]) -> Token {
+        guard let protocolToken = self as? ProtocolDeclaration else {
+            return self
+        }
+        return subjects.contains { $0.name == protocolToken.name } ? protocolToken.replace(isNSObjectProtocol: true) : self
     }
 
     static func findToken(forClassOrProtocol name: String, in files: [FileRepresentation]) -> Token? {

--- a/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
+++ b/Generator/Source/CuckooGeneratorFramework/Tokens/ProtocolDeclaration.swift
@@ -19,6 +19,7 @@ public struct ProtocolDeclaration: ContainerToken, HasAccessibility {
     public var inheritedTypes: [InheritanceDeclaration]
     public var attributes: [Attribute]
     public var genericParameters: [GenericParameter]
+    public var isNSObjectProtocol: Bool
 
     public func replace(children tokens: [Token]) -> ProtocolDeclaration {
         return ProtocolDeclaration(
@@ -32,7 +33,26 @@ public struct ProtocolDeclaration: ContainerToken, HasAccessibility {
             children: tokens,
             inheritedTypes: self.inheritedTypes,
             attributes: self.attributes,
-            genericParameters: self.genericParameters)
+            genericParameters: self.genericParameters,
+            isNSObjectProtocol: self.isNSObjectProtocol
+        )
+    }
+
+    public func replace(isNSObjectProtocol: Bool) -> ProtocolDeclaration {
+        ProtocolDeclaration(
+            name: self.name,
+            parent: self.parent,
+            accessibility: self.accessibility,
+            range: self.range,
+            nameRange: self.nameRange,
+            bodyRange: self.bodyRange,
+            initializers: self.initializers,
+            children: self.children,
+            inheritedTypes: self.inheritedTypes,
+            attributes: self.attributes,
+            genericParameters: self.genericParameters,
+            isNSObjectProtocol: isNSObjectProtocol
+        )
     }
 
     public func isEqual(to other: Token) -> Bool {

--- a/Tests/Swift/NSObjectProtocolInheritanceTest.swift
+++ b/Tests/Swift/NSObjectProtocolInheritanceTest.swift
@@ -1,0 +1,23 @@
+//
+//  NSObjectProtocolInheritanceTest.swift
+//  Cuckoo
+//
+//  Created by Shoto Kobayashi on 04/09/2022.
+//
+
+import XCTest
+
+class NSObjectProtocolTest: XCTestCase {
+
+    private var mockProtocolNotInheritingFromNSObjectProtocol: MockProtocolNotInheritingFromNSObjectProtocol!
+
+    override func setUp() {
+        super.setUp()
+
+        mockProtocolNotInheritingFromNSObjectProtocol = MockProtocolNotInheritingFromNSObjectProtocol()
+    }
+
+    func testProtocolNotInheritingFromNSObjectProtocol() {
+        XCTAssert(!(mockProtocolNotInheritingFromNSObjectProtocol is NSObject))
+    }
+}

--- a/Tests/Swift/Source/NSObjectProtocolInheritanceTesting.swift
+++ b/Tests/Swift/Source/NSObjectProtocolInheritanceTesting.swift
@@ -1,0 +1,32 @@
+//
+//  NSObjectProtocolInheritanceTesting.swift
+//  Cuckoo
+//
+//  Created by Shoto Kobayashi on 04/09/2022.
+//
+
+import Foundation
+
+protocol PlainProtocolToTestNSObjectProtocolInheritance {
+}
+
+protocol ProtocolNotInheritingFromNSObjectProtocol {
+}
+
+protocol ProtocolInheritingFromNSObjectProtocol: NSObjectProtocol {
+}
+
+protocol ChildProtocolInheritingFromNSObjectProtocol: ProtocolInheritingFromNSObjectProtocol {
+}
+
+protocol ProtocolInheritingFromNSObjectProtocolUsingProtocolComposition: NSObjectProtocol & PlainProtocolToTestNSObjectProtocolInheritance {
+}
+
+protocol ChildProtocolInheritingFromNSObjectProtocolUsingProtocolComposition: ProtocolInheritingFromNSObjectProtocolUsingProtocolComposition {
+}
+
+protocol ProtocolInheritingFromNSObjectProtocolAndOtherProtocol: NSObjectProtocol, PlainProtocolToTestNSObjectProtocolInheritance {
+}
+
+protocol ChildProtocolInheritingFromNSObjectProtocolAndOtherProtocol: ProtocolInheritingFromNSObjectProtocolAndOtherProtocol {
+}


### PR DESCRIPTION
I introduced support for NSObjectProtocol inheritance to fix #425.

If protocol inherits from NSObjectProtocol, Generated Mocks inherits from NSObject.

I used the logic suggested by @MatyasKriz with a slight modification to support Protocol Composition. 
```swift
// To support Protocol Composition like NSObject & SomeProtocol, I used following logic.
// Please see test protocol that I added.
let collapsedInheritedTypesName = protocolDeclaration.inheritedTypes.map({ $0.name.components(separatedBy: "&") }).joined().map({ $0.trimmingCharacters(in: .whitespaces) })
if collapsedInheritedTypesName.contains(where: { $0 == "NSObjectProtocol" }) {
    return true
}
```

Thanks.