### PR TITLE
Fix Cuckoo Generator to handle reserved keywords

### DIFF
--- a/Generator/Source/Internal/Generator.swift
+++ b/Generator/Source/Internal/Generator.swift
@@ -2,18 +2,6 @@ import Foundation
 import Stencil
 
 public struct Generator {
-    
-    private static let reservedKeywordsNotAllowedAsMethodName: Set = [
-        // Keywords used in declarations:
-        "associatedtype", "class", "deinit", "enum", "extension", "fileprivate", "func", "import", "init", "inout", "internal", "let", "operator", "private", "precedencegroup", "protocol", "public", "rethrows", "static", "struct", "subscript", "typealias", "var",
-        // Keywords used in statements:
-        "break", "case", "catch", "continue", "default", "defer", "do", "else", "fallthrough", "for", "guard", "if", "in", "repeat", "return", "throw", "switch", "where", "while",
-        // Keywords used in expressions and types:
-        "Any", "as", "catch", "false", "is", "nil", "rethrows", "self", "super", "throw", "throws", "true", "try",
-        // Keywords used in patterns:
-        "_",
-    ]
-
     private let declarations: [Token]
 
     public init(file: FileRepresentation) {
@@ -56,10 +44,10 @@ public struct Generator {
             guard let parameters = value as? [MethodParameter] else { return value }
             return self.closeNestedClosure(for: parameters)
         }
-        
+
         ext.registerFilter("escapeReservedKeywords") { (value: Any?) in
             guard let name = value as? String else { return value }
-            return self.escapeReservedKeywords(for: name)
+            return escapeReservedKeywords(for: name)
         }
 
         ext.registerFilter("removeClosureArgumentNames") { (value: Any?) in
@@ -110,7 +98,13 @@ public struct Generator {
         guard parameters.isEmpty == false else { return "let matchers: [Cuckoo.ParameterMatcher<Void>] = []" }
 
         let tupleType = parameters.map { $0.typeWithoutAttributes }.joined(separator: ", ")
-        let matchers = parameters.enumerated().map { "wrap(matchable: \($1.name)) { $0\(parameters.count > 1 ? ".\($0)" : "") }" }.joined(separator: ", ")
+
+        let matchers = parameters.enumerated().map { (index, parameter) in
+            let name = escapeReservedKeywords(for: parameter.name)
+            return "wrap(matchable: \(name)) { $0\(parameters.count > 1 ? ".\(index)" : "") }"
+        }
+        .joined(separator: ", ")
+
         return "let matchers: [Cuckoo.ParameterMatcher<(\(genericSafeType(from: tupleType)))>] = [\(matchers)]"
     }
 
@@ -150,10 +144,6 @@ public struct Generator {
             }
         }
         return fullString
-    }
-    
-    private func escapeReservedKeywords(for name: String) -> String {
-        Self.reservedKeywordsNotAllowedAsMethodName.contains(name) ? "`\(name)`" : name
     }
 
     private func removeClosureArgumentNames(for type: String) -> String {

--- a/Generator/Source/Internal/Templates/MockTemplate.swift
+++ b/Generator/Source/Internal/Templates/MockTemplate.swift
@@ -118,8 +118,8 @@ extension {{ container.parentFullyQualifiedName }} {
     \"\"\"
     {{method.fullyQualifiedName}}
     \"\"\",
-            parameters: ({{method.parameterNames}}),
-            escapingParameters: ({{method.escapingParameterNames}}),
+            parameters: ({{method.parameterNames|escapeReservedKeywords}}),
+            escapingParameters: ({{method.escapingParameterNames|escapeReservedKeywords}}),
             superclassCall:
                 {% if container.isImplementation %}
                 {% if method.isAsync %}await {% endif %}super.{{method.name}}({{method.call}})

--- a/Generator/Source/Internal/Tokens/Method.swift
+++ b/Generator/Source/Internal/Tokens/Method.swift
@@ -38,11 +38,11 @@ public extension Method {
             .map { $0 + ": " + $1 }
             .joined(separator: ", ") + lastNamePart + returnSignatureString
     }
-    
+
     var isAsync: Bool {
         return returnSignature.isAsync
     }
-    
+
     var isThrowing: Bool {
         guard let throwType = returnSignature.throwType else { return false }
         return throwType.isThrowing || throwType.isRethrowing
@@ -67,7 +67,9 @@ public extension Method {
 
     func serialize() -> [String : Any] {
         let call = parameters.map {
-            let referencedName = "\($0.isInout ? "&" : "")\($0.name)"
+            let name = escapeReservedKeywords(for: $0.name)
+            let referencedName = "\($0.isInout ? "&" : "")\(name)"
+
             if let label = $0.label {
                 return "\(label): \(referencedName)"
             } else {

--- a/Generator/Source/Internal/Utils.swift
+++ b/Generator/Source/Internal/Utils.swift
@@ -48,9 +48,29 @@ extension Sequence {
     }
 }
 
+/// Utility function for escaping reserved keywords for a symbol name.
+internal func escapeReservedKeywords(for name: String) -> String {
+    reservedKeywordsNotAllowed.contains(name) ? "`\(name)`" : name
+}
+
 internal func extractRange(from dictionary: [String: SourceKitRepresentable], offset: Key, length: Key) -> CountableRange<Int>? {
     guard let offset = (dictionary[offset.rawValue] as? Int64).map(Int.init),
         let length = (dictionary[length.rawValue] as? Int64).map(Int.init) else { return nil }
 
     return offset..<offset.advanced(by: length)
 }
+
+/// Reserved keywords that are not allowed as function names, function parameters, or local variables, etc.
+fileprivate let reservedKeywordsNotAllowed: Set = [
+    // Keywords used in declarations:
+    "associatedtype", "class", "deinit", "enum", "extension", "fileprivate", "func", "import", "init", "inout",
+    "internal", "let", "operator", "private", "precedencegroup", "protocol", "public", "rethrows", "static",
+    "struct", "subscript", "typealias", "var",
+    // Keywords used in statements:
+    "break", "case", "catch", "continue", "default", "defer", "do", "else", "fallthrough", "for", "guard", "if", "in",
+    "repeat", "return", "throw", "switch", "where", "while",
+    // Keywords used in expressions and types:
+    "Any", "as", "catch", "false", "is", "nil", "rethrows", "self", "super", "throw", "throws", "true", "try",
+    // Keywords used in patterns:
+    "_",
+]


### PR DESCRIPTION
Allows for reserved keywords to be used as argument labels / parameters in mocked types.

Fixes: https://github.com/Brightify/Cuckoo/issues/452

- Moves escaping util function to Utils and makes it internal since it now needs to be used outside of `Generator`.
- Uses escaping function in areas affected by the bug.
- Renames set of reserved names to reflect the larger scope (no longer used for just function names).
- Some minor clean-up to style and formatting on areas touched.

With this change you can now mock functions like:
https://developer.apple.com/documentation/foundation/filemanager/1407693-url on `FileManager`.

Example of the problem:

Generate a mock for a protocol with the function:

```
func escape(for name: String) -> String
```

This would result in `for` as a function parameter used within the body of the function for the mock and verification and stubbing proxies, which would not compile. This change escapes keywords like this so the generated code will compile.

Note: There was previous attempt at escaping reserved keywords (https://github.com/Brightify/Cuckoo/pull/412), but it was incomplete and only handled the case of a function name using a reserved keyword, which seems to be less common since Apple's frameworks have many functions and initializers that use `for` or `in` as an argument label.