### PR TITLE
Fix Generator to handle reserved keywords

### DIFF
--- a/Generator/Source/Internal/Tokens/Method.swift
+++ b/Generator/Source/Internal/Tokens/Method.swift
@@ -38,11 +38,11 @@ public extension Method {
             .map { $0 + ": " + $1 }
             .joined(separator: ", ") + lastNamePart + returnSignatureString
     }
-    
+
     var isAsync: Bool {
         return returnSignature.isAsync
     }
-    
+
     var isThrowing: Bool {
         guard let throwType = returnSignature.throwType else { return false }
         return throwType.isThrowing || throwType.isRethrowing
@@ -67,7 +67,9 @@ public extension Method {
 
     func serialize() -> [String : Any] {
         let call = parameters.map {
-            let referencedName = "\($0.isInout ? "&" : "")\($0.name)\($0.isAutoClosure ? "()" : "")"
+            let name = escapeReservedKeywords(for: $0.name)
+            let referencedName = "\($0.isInout ? "&" : "")\(name)\($0.isAutoClosure ? "()" : "")"
+
             if let label = $0.label {
                 return "\(label): \(referencedName)"
             } else {
@@ -95,7 +97,7 @@ public extension Method {
                 }
                 return "{ \(parameterSignature)\(returnSignature) in fatalError(\"This is a stub! It's not supposed to be called!\") }"
             } else {
-                return parameter.name
+                return escapeReservedKeywords(for: parameter.name)
             }
         }.joined(separator: ", ")
 
@@ -108,7 +110,7 @@ public extension Method {
             "accessibility": accessibility.sourceName,
             "returnSignature": returnSignature.description,
             "parameters": parameters,
-            "parameterNames": parameters.map { $0.name }.joined(separator: ", "),
+            "parameterNames": parameters.map { escapeReservedKeywords(for: $0.name) }.joined(separator: ", "),
             "escapingParameterNames": escapingParameterNames,
             "isInit": isInit,
             "returnType": returnType.explicitOptionalOnly.sugarized,

--- a/Generator/Source/Internal/Utils.swift
+++ b/Generator/Source/Internal/Utils.swift
@@ -48,6 +48,26 @@ extension Sequence {
     }
 }
 
+/// Reserved keywords that are not allowed as function names, function parameters, or local variables, etc.
+fileprivate let reservedKeywordsNotAllowed: Set = [
+    // Keywords used in declarations:
+    "associatedtype", "class", "deinit", "enum", "extension", "fileprivate", "func", "import", "init", "inout",
+    "internal", "let", "operator", "private", "precedencegroup", "protocol", "public", "rethrows", "static",
+    "struct", "subscript", "typealias", "var",
+    // Keywords used in statements:
+    "break", "case", "catch", "continue", "default", "defer", "do", "else", "fallthrough", "for", "guard", "if", "in",
+    "repeat", "return", "throw", "switch", "where", "while",
+    // Keywords used in expressions and types:
+    "Any", "as", "catch", "false", "is", "nil", "rethrows", "self", "super", "throw", "throws", "true", "try",
+    // Keywords used in patterns:
+    "_",
+]
+
+/// Utility function for escaping reserved keywords for a symbol name.
+internal func escapeReservedKeywords(for name: String) -> String {
+    reservedKeywordsNotAllowed.contains(name) ? "`\(name)`" : name
+}
+
 internal func extractRange(from dictionary: [String: SourceKitRepresentable], offset: Key, length: Key) -> CountableRange<Int>? {
     guard let offset = (dictionary[offset.rawValue] as? Int64).map(Int.init),
         let length = (dictionary[length.rawValue] as? Int64).map(Int.init) else { return nil }

--- a/Tests/Swift/Source/TestedClass.swift
+++ b/Tests/Swift/Source/TestedClass.swift
@@ -148,6 +148,10 @@ class TestedClass {
     func withLabelAndUnderscore(labelA a: String, _ b: String) {
     }
 
+    func withReservedKeywords(for: String, in: String) -> String {
+        "hello"
+    }
+
     func callingCountCharactersMethodWithHello() -> Int {
         return count(characters: "Hello")
     }

--- a/Tests/Swift/Source/TestedProtocol.swift
+++ b/Tests/Swift/Source/TestedProtocol.swift
@@ -56,6 +56,14 @@ protocol TestedProtocol {
 
     func withLabelAndUnderscore(labelA a: String, _ b: String)
 
+    /// In this example `for` and `in` are not actually used in a way that conflicts with reserved keywords because
+    /// conforming types will typically use `for` and `in` as an argument label for parameter with a different name,
+    /// thus avoiding the usage of a reserved keyword in the body of the function.
+    ///
+    /// The problem was with the generated mock code, which was in turn using these in the body without escaping them,
+    /// causing the generated mock code to fail to compile.
+    func withReservedKeywords(for: String, in: String) -> String
+
     func withNamedTuple(tuple: (a: String, b: String)) -> Int
 
     func withImplicitlyUnwrappedOptional(i: Int!) -> String


### PR DESCRIPTION
Allows for reserved keywords to be used as argument labels / parameters
in mocked types.

Fixes: https://github.com/Brightify/Cuckoo/issues/452

- Moves escaping util function to Utils and makes it internal since it
  now needs to be used outside of `Generator`.
- Uses escaping function in areas affected by the bug.
- Renames set of reserved names to reflect the larger scope (no longer
  used for just function names).
- Some minor clean-up to style and formatting on areas touched.

Example of the problem:

Generate a mock for a protocol with the function:

```
func escape(for: String) -> String
```

This would result in `for` as a function parameter used within the body
of the function for the mock and verification and stubbing proxies,
which would not compile. This change escapes keywords like this so the
generated code will compile.

See `TestedProtocol.withReservedKeywords` for a test example. An example
was added to `TestedClass` as well, but the real motivation for this is
protocols since conforming types can and often do use a different parameter
name so the argument label like `for` would never be used within the
body of the function.