### PR TITLE
Fix property wrapper crash

### DIFF
--- a/Generator/Source/Internal/TypeGuesser.swift
+++ b/Generator/Source/Internal/TypeGuesser.swift
@@ -3,6 +3,8 @@ import Foundation
 struct TypeGuesser {
     static func guessType(from value: String) -> String? {
         let value = value.trimmed
+        guard !value.isEmpty else { return nil }
+
         let casting = checkCasting(from: value)
         guard casting == nil else { return casting }
 

--- a/Tests/Swift/Source/PropertyWrappers.swift
+++ b/Tests/Swift/Source/PropertyWrappers.swift
@@ -5,6 +5,9 @@
 //  Created by Kabir Oberai on 2023-03-28.
 //
 
+// wrappers without annotations aren't supported but their
+// existence shouldn't cause the generator to crash
+
 @propertyWrapper
 struct DoublingWrapper {
     private var backing: Int
@@ -21,9 +24,6 @@ struct DoublingWrapper {
         self.backing = 0
     }
 }
-
-// wrappers without annotations aren't supported but their
-// existence shouldn't cause the generator to crash
 
 struct Wrappers {
     @DoublingWrapper var base

--- a/Tests/Swift/Source/PropertyWrappers.swift
+++ b/Tests/Swift/Source/PropertyWrappers.swift
@@ -1,0 +1,33 @@
+//
+//  PropertyWrappers.swift
+//  Cuckoo
+//
+//  Created by Kabir Oberai on 2023-03-28.
+//
+
+@propertyWrapper
+struct DoublingWrapper {
+    private var backing: Int
+    var wrappedValue: Int {
+        get { backing * 2 }
+        set { backing = newValue }
+    }
+
+    init(wrappedValue: Int) {
+        self.backing = wrappedValue
+    }
+
+    init() {
+        self.backing = 0
+    }
+}
+
+// wrappers without annotations aren't supported but their
+// existence shouldn't cause the generator to crash
+
+struct Wrappers {
+    @DoublingWrapper var base
+    @DoublingWrapper var withValue = 2
+    @DoublingWrapper var withAnnotation: Int
+    @DoublingWrapper var withAnnotationAndValue: Int = 2
+}


### PR DESCRIPTION
This PR doesn't endeavour to enable type inference for property wrappers without type annotations, but it does allow them to exist in the user's source without causing Cuckoo to crash. This sort of pattern is super common in SwiftUI views, for example, which often have declarations like `@Environment(\.colorScheme) var colorScheme`.

Fixes #341.