### PR TITLE
Add SPM package plugin

### DIFF
--- a/Generator/Plugin/Plugin.swift
+++ b/Generator/Plugin/Plugin.swift
@@ -1,0 +1,44 @@
+import PackagePlugin
+
+@main struct CuckooPlugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) async throws -> [PackagePlugin.Command] {
+        let dependencies: [SourceModuleTarget] = target
+            .dependencies
+            .flatMap { dependency in
+                switch dependency {
+                case .product(let product):
+                    return product.targets
+                case .target(let target):
+                    return [target]
+                @unknown default:
+                    return []
+                }
+            }
+            .compactMap { $0 as? SourceModuleTarget }
+            .filter { $0.kind == .generic && $0.moduleName != "Cuckoo" }
+
+        let testableModules = dependencies
+            .map(\.moduleName)
+            .joined(separator: ",")
+
+        let sources = dependencies
+            .flatMap(\.sourceFiles)
+            .filter { $0.type == .source }
+            .map(\.path)
+
+        let output = context.pluginWorkDirectory.appending("GeneratedMocks.swift")
+
+        return [.buildCommand(
+            displayName: "Run CuckooGenerator",
+            executable: try context.tool(named: "CuckooGenerator").path,
+            arguments: [
+                "generate",
+                "--output", output,
+                "--testable", testableModules,
+                "--regex", "Mockable.*"
+            ] + sources,
+            inputFiles: sources,
+            outputFiles: [output]
+        )]
+    }
+}

--- a/Generator/Plugin/Plugin.swift
+++ b/Generator/Plugin/Plugin.swift
@@ -3,7 +3,7 @@ import Foundation
 
 @main struct CuckooPlugin: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) async throws -> [PackagePlugin.Command] {
-        let configPath = context.package.directory.appending("cuckoo-config.json")
+        let configPath = context.package.directory.appending("cuckoo.json")
         let config = try await ConfigFile.decode(from: configPath)
 
         let dependencies: [SourceModuleTarget] = target

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -1,0 +1,52 @@
+// swift-tools-version:5.7
+
+import PackageDescription
+
+let package = Package(
+    name: "Cuckoo",
+    platforms: [.macOS("12.0")],
+    products: [
+        .library(
+            name: "Cuckoo",
+            targets: ["Cuckoo"]
+        ),
+        .plugin(
+            name: "CuckooPlugin",
+            targets: ["CuckooPlugin"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/jpsim/SourceKitten.git", .upToNextMinor(from: "0.34.1")),
+        .package(url: "https://github.com/nvzqz/FileKit.git", branch: "develop"),
+        .package(url: "https://github.com/kylef/Stencil.git", exact: "0.14.2"),
+        .package(url: "https://github.com/Carthage/Commandant.git", exact: "0.15.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "CuckooGenerator",
+            dependencies: [
+                .product(name: "SourceKittenFramework", package: "SourceKitten"),
+                .product(name: "FileKit", package: "FileKit"),
+                .product(name: "Stencil", package: "Stencil"),
+                .product(name: "Commandant", package: "Commandant"),
+            ],
+            path: "Generator/Source"
+        ),
+        .plugin(
+            name: "CuckooPlugin",
+            capability: .buildTool(),
+            dependencies: ["CuckooGenerator"],
+            path: "Generator/Plugin"
+        ),
+        .target(
+            name: "Cuckoo",
+            dependencies: [],
+            path: "Source"
+        ),
+        .testTarget(
+            name: "CuckooTests",
+            dependencies: ["Cuckoo"],
+            path: "Tests"
+        ),
+    ]
+)


### PR DESCRIPTION
Closes #438.

Using the plugin is simple: just add `plugins: [.plugin(name: "CuckooPlugin", package: "Cuckoo")]` to the corresponding `testTarget`. The plugin currently passes all modules that are _direct_ dependencies of the test target to the generator.

Since there's no API for directly configuring plugins from Package.swift yet, the plugin currently looks for a `cuckoo.json` file in the package root dir, which can currently be used to supply additional command-line options. IMO using json makes sense for now because it's one of the easiest formats to parse in Swift. We can always switch to something more expressive like YAML in the future, since the config file is versioned and YAML is designed to be backwards-compatible with JSON.