### PR TITLE
Support effectful properties

### DIFF
--- a/Generator/Source/Internal/Templates/MockTemplate.swift
+++ b/Generator/Source/Internal/Templates/MockTemplate.swift
@@ -60,15 +60,15 @@ extension {{ container.parentFullyQualifiedName }} {
     {{ attribute.text }}
     {% endfor %}
     {{ property.accessibility }}{% if container.isImplementation %} override{% endif %} var {{ property.name }}: {{ property.type }} {
-        get {
-            return cuckoo_manager.getter("{{ property.name }}",
+        get{% if property.isAsync %} async{% endif %}{% if property.isThrowing %} throws{% endif %} {
+            return {% if property.isThrowing %}try {% endif %}{% if property.isAsync %}await {% endif %}cuckoo_manager.getter{% if property.isThrowing %}Throws{% endif %}("{{ property.name }}",
                 superclassCall:
                     {% if container.isImplementation %}
-                    super.{{ property.name }}
+                                    {% if property.isThrowing %}try {% endif %}{% if property.isAsync %}await {% endif %}super.{{ property.name }}
                     {% else %}
                     Cuckoo.MockManager.crashOnProtocolSuperclassCall()
                     {% endif %},
-                defaultCall: __defaultImplStub!.{{property.name}})
+                defaultCall: {% if property.isThrowing %}try {% endif %}{% if property.isAsync %}await {% endif %} __defaultImplStub!.{{property.name}})
         }
         {% ifnot property.isReadOnly %}
         set {

--- a/Generator/Source/Internal/Tokens/InstanceVariable.swift
+++ b/Generator/Source/Internal/Tokens/InstanceVariable.swift
@@ -1,8 +1,14 @@
 public struct InstanceVariable: Token, HasAccessibility, HasAttributes {
+    public struct Effects {
+        public var isThrowing = false
+        public var isAsync = false
+    }
+
     public var name: String
     public var type: WrappableType
     public var accessibility: Accessibility
     public var setterAccessibility: Accessibility?
+    public var effects: Effects
     public var range: CountableRange<Int>
     public var nameRange: CountableRange<Int>
     public var overriding: Bool
@@ -22,8 +28,10 @@ public struct InstanceVariable: Token, HasAccessibility, HasAttributes {
     }
 
     public func serialize() -> [String : Any] {
-        let readOnlyString = readOnly ? "ReadOnly" : ""
+        let readOnlyVerifyString = readOnly ? "ReadOnly" : ""
+        let readOnlyStubString = effects.isThrowing ? "" : readOnlyVerifyString
         let optionalString = type.isOptional && !readOnly ? "Optional" : ""
+        let throwingString = effects.isThrowing ? "Throwing" : ""
 
         return [
             "name": name,
@@ -31,8 +39,10 @@ public struct InstanceVariable: Token, HasAccessibility, HasAttributes {
             "nonOptionalType": type.unoptionaled.sugarized,
             "accessibility": accessibility.sourceName,
             "isReadOnly": readOnly,
-            "stubType": (overriding ? "Class" : "Protocol") + "ToBeStubbed\(readOnlyString)\(optionalString)Property",
-            "verifyType": "Verify\(readOnlyString)\(optionalString)Property",
+            "isAsync": effects.isAsync,
+            "isThrowing": effects.isThrowing,
+            "stubType": (overriding ? "Class" : "Protocol") + "ToBeStubbed\(readOnlyStubString)\(optionalString)\(throwingString)Property",
+            "verifyType": "Verify\(readOnlyVerifyString)\(optionalString)Property",
             "attributes": attributes.filter { $0.isSupported },
             "hasUnavailablePlatforms": hasUnavailablePlatforms,
             "unavailablePlatformsCheck": unavailablePlatformsCheck,

--- a/Source/MockManager.swift
+++ b/Source/MockManager.swift
@@ -310,8 +310,24 @@ extension MockManager {
         return call(getterName(property), parameters: Void(), escapingParameters: Void(), superclassCall: superclassCall(), defaultCall: defaultCall())
     }
 
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    public func getter<T>(_ property: String, superclassCall: @autoclosure () async -> T, defaultCall: @autoclosure () async -> T) async -> T {
+        return await call(getterName(property), parameters: Void(), escapingParameters: Void(), superclassCall: await superclassCall(), defaultCall: await defaultCall())
+    }
+
     public func setter<T>(_ property: String, value: T, superclassCall: @autoclosure () -> Void, defaultCall: @autoclosure () -> Void) {
         return call(setterName(property), parameters: value, escapingParameters: value, superclassCall: superclassCall(), defaultCall: defaultCall())
+    }
+}
+
+extension MockManager {
+    public func getterThrows<T>(_ property: String, superclassCall: @autoclosure () throws -> T, defaultCall: @autoclosure () throws -> T) throws -> T {
+        return try callThrows(getterName(property), parameters: Void(), escapingParameters: Void(), superclassCall: try superclassCall(), defaultCall: try defaultCall())
+    }
+
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    public func getterThrows<T>(_ property: String, superclassCall: @autoclosure () async throws -> T, defaultCall: @autoclosure () async throws -> T) async throws -> T {
+        return try await callThrows(getterName(property), parameters: Void(), escapingParameters: Void(), superclassCall: try await superclassCall(), defaultCall: try await defaultCall())
     }
 }
 

--- a/Source/Stubbing/ToBeStubbedProperty/ToBeStubbedThrowingProperty.swift
+++ b/Source/Stubbing/ToBeStubbedProperty/ToBeStubbedThrowingProperty.swift
@@ -1,0 +1,42 @@
+//
+//  ToBeStubbedThrowingProperty.swift
+//  Cuckoo
+//
+//  Created by Kabir Oberai on 2023-03-27.
+//
+
+public protocol ToBeStubbedThrowingProperty {
+    associatedtype GetterType: StubThrowingFunction
+
+    var get: GetterType { get }
+}
+
+public struct ProtocolToBeStubbedThrowingProperty<MOCK: ProtocolMock, T>: ToBeStubbedThrowingProperty {
+    private let manager: MockManager
+    private let name: String
+
+    public var get: ProtocolStubThrowingFunction<Void, T> {
+        return ProtocolStubThrowingFunction(stub:
+            manager.createStub(for: MOCK.self, method: getterName(name), parameterMatchers: []))
+    }
+
+    public init(manager: MockManager, name: String) {
+        self.manager = manager
+        self.name = name
+    }
+}
+
+public struct ClassToBeStubbedThrowingProperty<MOCK: ClassMock, T>: ToBeStubbedThrowingProperty {
+    private let manager: MockManager
+    private let name: String
+
+    public var get: ClassStubThrowingFunction<Void, T> {
+        return ClassStubThrowingFunction(stub:
+            manager.createStub(for: MOCK.self, method: getterName(name), parameterMatchers: []))
+    }
+
+    public init(manager: MockManager, name: String) {
+        self.manager = manager
+        self.name = name
+    }
+}

--- a/Tests/Swift/ProtocolTest.swift
+++ b/Tests/Swift/ProtocolTest.swift
@@ -58,6 +58,61 @@ class ProtocolTest: XCTestCase {
         verify(mock).optionalProperty.set(equal(to: 0))
     }
 
+    func testThrowingProperty() {
+        stub(mock) { mock in
+            when(mock.throwsProperty.get).thenReturn(5)
+        }
+
+        XCTAssertEqual(try mock.throwsProperty, 5)
+        verify(mock).throwsProperty.get()
+
+        clearInvocations(mock)
+
+        stub(mock) { mock in
+            when(mock.throwsProperty.get).thenThrow(TestError.unknown)
+        }
+
+        XCTAssertThrowsError(try mock.throwsProperty)
+
+        verify(mock).throwsProperty.get()
+    }
+
+    func testAsyncProperty() async {
+        stub(mock) { mock in
+            when(mock.asyncProperty.get).thenReturn(5)
+        }
+
+        let result = await mock.asyncProperty
+        XCTAssertEqual(result, 5)
+        verify(mock).asyncProperty.get()
+    }
+
+    func testAsyncThrowingProperty() async {
+        stub(mock) { mock in
+            when(mock.asyncThrowsProperty.get).thenReturn(5)
+        }
+
+        let result = try! await mock.asyncThrowsProperty
+        XCTAssertEqual(result, 5)
+        verify(mock).asyncThrowsProperty.get()
+
+        clearInvocations(mock)
+
+        stub(mock) { mock in
+            when(mock.asyncThrowsProperty.get).thenThrow(TestError.unknown)
+        }
+
+        var threw = false
+        do {
+            _ = try await mock.asyncThrowsProperty
+        } catch {
+            threw = true
+        }
+
+        XCTAssertTrue(threw)
+        verify(mock).asyncThrowsProperty.get()
+    }
+
     func testNoReturn() {
         var called = false
         stub(mock) { mock in

--- a/Tests/Swift/Source/TestedClass.swift
+++ b/Tests/Swift/Source/TestedClass.swift
@@ -53,6 +53,18 @@ class TestedClass {
         ) -> String
     ) -> () = { i in }
 
+    var asyncProperty: Int {
+        get async { 0 }
+    }
+
+    var asyncThrowsProperty: Int {
+        get async throws { 0 }
+    }
+
+    var throwsProperty: Int {
+        get throws { 0 }
+    }
+
     func noReturn() {
     }
 

--- a/Tests/Swift/Source/TestedProtocol.swift
+++ b/Tests/Swift/Source/TestedProtocol.swift
@@ -34,6 +34,14 @@ protocol TestedProtocol {
         ) -> String
     ) -> () { get set }
 
+    var throwsProperty: Int { get throws }
+
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    var asyncProperty: Int { get async }
+
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    var asyncThrowsProperty: Int { get async throws }
+
     func noReturn()
 
     func count(characters: String) -> Int

--- a/Tests/Swift/Stubbing/StubbingTest.swift
+++ b/Tests/Swift/Stubbing/StubbingTest.swift
@@ -124,6 +124,55 @@ class StubbingTest: XCTestCase {
 
         XCTAssertEqual(mock.protocolMethod(), "a1")
     }
+
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func testEffectfulProps() async {
+        let mock = MockTestedSubSubClass()
+
+        XCTAssertNotNil(mock)
+
+        stub(mock) { stub in
+            when(stub.asyncProperty.get).thenReturn(5)
+            when(stub.throwsProperty.get).thenReturn(6)
+            when(stub.asyncThrowsProperty.get).thenReturn(7)
+        }
+
+        let resultAsync = await mock.asyncProperty
+        XCTAssertEqual(resultAsync, 5)
+
+        let resultThrows = try! mock.throwsProperty
+        XCTAssertEqual(resultThrows, 6)
+
+        let resultAsyncThrows = try! await mock.asyncThrowsProperty
+        XCTAssertEqual(resultAsyncThrows, 7)
+
+        verify(mock, times(1)).asyncProperty.get()
+        verify(mock, times(1)).throwsProperty.get()
+        verify(mock, times(1)).asyncThrowsProperty.get()
+
+        enum TestError: Error { case fromThrows, fromAsyncThrows }
+
+        stub(mock) { stub in
+            when(stub.throwsProperty.get).thenThrow(TestError.fromThrows)
+            when(stub.asyncThrowsProperty.get).thenThrow(TestError.fromAsyncThrows)
+        }
+
+        var caughtFromThrows = false
+        do {
+            _ = try mock.throwsProperty
+        } catch TestError.fromThrows {
+            caughtFromThrows = true
+        } catch {}
+        XCTAssert(caughtFromThrows)
+
+        var caughtFromAsyncThrows = false
+        do {
+            _ = try await mock.asyncThrowsProperty
+        } catch TestError.fromAsyncThrows {
+            caughtFromAsyncThrows = true
+        } catch {}
+        XCTAssert(caughtFromAsyncThrows)
+    }
     
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func testAsyncMethods() async {


### PR DESCRIPTION
This PR allows Cuckoo to properly handle read-only properties with getters marked as `async` or `throws`, as specified by [SE-0310](https://github.com/apple/swift-evolution/blob/main/proposals/0310-effectful-readonly-properties.md).

Note that I'm not 100% sure I have all the availability annotations correct so lmk if there are any problems with that.