### PR TITLE
Add ability to customize start/end of each generated file

### DIFF
--- a/Cuckoofile.toml
+++ b/Cuckoofile.toml
@@ -12,10 +12,17 @@ exclude = [
 ]
 # regex = ""
 output = "Tests/Swift/Generated/GeneratedMocks.swift"
+# output = "Tests/Swift/Generated/"
 
 [modules.Cuckoo.options]
 glob = true
 keepDocumentation = false
+filePrefix = [
+    "// swiftlint:disable all",
+]
+fileSuffix = [
+    "// swiftlint:enable all",
+]
 
 [modules.Cuckoo.xcodeproj]
 path = "Generator"

--- a/Generator/Sources/CLI/GenerateCommand.swift
+++ b/Generator/Sources/CLI/GenerateCommand.swift
@@ -88,7 +88,7 @@ struct GenerateCommand: AsyncParsableCommand {
                             ?? originalFileName
                         let outputFile = TextFile(path: absoluteOutputPath + "\(fileNameWithoutExtension).swift")
                         do {
-                            try outputFile.write(generatedFile.contents)
+                            try outputFile.write(module.options.filePrefix + generatedFile.contents + module.options.fileSuffix)
                         } catch {
                             log(.error, message: "Failed to write to file '\(outputFile)':", error)
                         }
@@ -96,7 +96,7 @@ struct GenerateCommand: AsyncParsableCommand {
                 } else {
                     let outputFile = TextFile(path: absoluteOutputPath)
                     do {
-                        try outputFile.write(generatedFiles.map(\.contents).joined(separator: "\n\n"))
+                        try outputFile.write(module.options.filePrefix + generatedFiles.map(\.contents).joined(separator: "\n\n") + module.options.filePrefix)
                     } catch {
                         log(.error, message: "Failed to write to file '\(outputFile)':", error)
                     }

--- a/Generator/Sources/CLI/Module.swift
+++ b/Generator/Sources/CLI/Module.swift
@@ -35,7 +35,9 @@ final class Module {
             keepDocumentation: dto.options?.keepDocumentation ?? true,
             enableInheritance: dto.options?.enableInheritance ?? true,
             protocolsOnly: dto.options?.protocolsOnly ?? false,
-            omitHeaders: dto.options?.omitHeaders ?? false
+            omitHeaders: dto.options?.omitHeaders ?? false,
+            filePrefix: dto.options?.filePrefix?.joined(separator: "\n").appending("\n") ?? "",
+            fileSuffix: dto.options?.fileSuffix?.joined(separator: "\n").appending("\n") ?? ""
         )
 
         if let xcodeproj = dto.xcodeproj {
@@ -64,6 +66,8 @@ final class Module {
         let enableInheritance: Bool
         let protocolsOnly: Bool
         let omitHeaders: Bool
+        let filePrefix: String
+        let fileSuffix: String
     }
 
     struct Xcodeproj {
@@ -107,6 +111,8 @@ extension Module {
             let enableInheritance: Bool?
             let protocolsOnly: Bool?
             let omitHeaders: Bool?
+            let filePrefix: [String]?
+            let fileSuffix: [String]?
         }
 
         struct Xcodeproj: Decodable {

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ sources = [
 ]
 exclude = ["ExcludedTestClass"]
 
-s# Optionally you can use a regular expression to filter only specific classes/protocols.
+# Optionally you can use a regular expression to filter only specific classes/protocols.
 # regex = ""
 
 [modules.MyProject.options]

--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ sources = [
     "Tests/Swift/Source/*.swift",
 ]
 exclude = ["ExcludedTestClass"]
-# Optionally you can use a regular expression to filter only specific classes/protocols.
+
+s# Optionally you can use a regular expression to filter only specific classes/protocols.
 # regex = ""
 
 [modules.MyProject.options]
@@ -136,6 +137,15 @@ keepDocumentation = false
 # enableInheritance = false
 # protocolsOnly = true
 # omitHeaders = true
+
+# You can add prefix lines to the beginning of each file written, and suffix lines to the end
+# For example, this config can be used to turn swiftlint off at the start and back on at the end
+prefixLines = [
+    "// swiftlint:disable all",
+]
+SuffixLines = [
+    "// swiftlint:enable all",
+]
 
 # If specified, Cuckoo can also get sources for the module from an Xcode target.
 [modules.MyProject.xcodeproj]


### PR DESCRIPTION
This PR adds two properties to the options, to allow per-file customization. For example, you can use this to turn swiftlint on and off, but there are other uses.

```
[modules.MyProject.options]

# You can add prefix lines to the beginning of each file written, and suffix lines to the end
# For example, this config can be used to turn swiftlint off at the start and back on at the end
prefixLines = [
    "// swiftlint:disable all",
]
SuffixLines = [
    "// swiftlint:enable all",
]

```