### PR TITLE
Update Version.swift

### DIFF
--- a/Generator/Sources/CLI/Version.swift
+++ b/Generator/Sources/CLI/Version.swift
@@ -1,1 +1,1 @@
-let version = "2.0.0"
+let version = "2.0.10"


### PR DESCRIPTION
The hard coded Version should be updated - shouldn't it?
I do wonder if this file should be automatically generated during the cuckoonator build according to the version in the `version` file that is updated no every release?