### PR TITLE
Fixed typeErasure template when method.isThrowing

### DIFF
--- a/Generator/Sources/Internal/Templates/TypeErasureTemplate.swift
+++ b/Generator/Sources/Internal/Templates/TypeErasureTemplate.swift
@@ -43,9 +43,9 @@ extension Templates {
         {% endfor %}
 
         {% for method in container.methods +%}
-        private let _storage${{ forloop.counter }}${{ method.name }}: ({{ method.inputTypes }}) {% if method.isAsync %} async{% endif %} -> {{ method.returnType }}
+        private let _storage${{ forloop.counter }}${{ method.name }}: ({{ method.inputTypes }}) {% if method.isAsync %} async{% endif %} {% if method.isThrowing %} throws{% endif %} -> {{ method.returnType }}
         {{ container.accessibility|withSpace }}func {{ method.name|escapeReservedKeywords }}{{ method.signature }} {
-            return {% if method.isAsync %} await{% endif %} _storage${{ forloop.counter }}${{ method.name }}({{ method.parameterNames }})
+            return {% if method.isThrowing %} try{% endif %} {% if method.isAsync %} await{% endif %} _storage${{ forloop.counter }}${{ method.name }}({{ method.parameterNames }})
         }
         {% endfor %}
     }


### PR DESCRIPTION
typeErasure template was missing the logic to check for method throws while assigning defaultImpl