### PR TITLE
Public imports option for configuration

### DIFF
--- a/Generator/Sources/CLI/Generator.swift
+++ b/Generator/Sources/CLI/Generator.swift
@@ -70,7 +70,7 @@ final class Generator {
                 path: file.file.path,
                 contents: [
                     module.options.omitHeaders ? nil : FileHeaderHandler.header(for: file, timestamp: timestamp),
-                    FileHeaderHandler.imports(for: file, imports: module.imports, testableImports: module.testableImports),
+                    FileHeaderHandler.imports(for: file, imports: module.imports, publicImports: module.publicImports, testableImports: module.testableImports),
                     try GeneratorHelper.generate(tokens: file.tokens),
                 ]
                 .compactMap { $0 }

--- a/Generator/Sources/CLI/Module.swift
+++ b/Generator/Sources/CLI/Module.swift
@@ -123,6 +123,7 @@ extension Module: CustomDebugStringConvertible {
     var debugDescription: String {
         [
             "imports:\(imports.map { "\n\t-\($0.bold)" }.joined(separator: ", "))",
+            "public imports:\(publicImports.map { "\n\t-\($0.bold)" }.joined(separator: ", "))",
             "testable imports:\(testableImports.map { "\n\t-\($0.bold)" }.joined(separator: ", "))",
             sources.map { "sources:\($0.map { "\n\t-\($0.rawValue.bold)" }.joined())" },
             "excluded types:\(exclude.map { "\n\t-\($0.bold)" }.joined())",

--- a/Generator/Sources/CLI/Module.swift
+++ b/Generator/Sources/CLI/Module.swift
@@ -6,6 +6,7 @@ final class Module {
 
     let name: String
     let imports: [String]
+    let publicImports: [String]
     let testableImports: [String]
     let sources: [Path]?
     let exclude: [String]
@@ -22,6 +23,7 @@ final class Module {
 
         self.name = name
         self.imports = dto.imports?.map(\.trimmed) ?? []
+        self.publicImports = dto.publicImports?.map(\.trimmed) ?? []
         self.testableImports = dto.testableImports?.map(\.trimmed) ?? []
         self.sources = dto.sources?.map(\.trimmed).map { source in
             Path(source, expandingTilde: true).relative(to: configurationPath.parent)
@@ -92,6 +94,7 @@ final class Module {
 extension Module {
     struct DTO: Decodable {
         let imports: [String]?
+        let publicImports: [String]?
         let testableImports: [String]?
         let sources: [String]?
         let exclude: [String]?

--- a/Generator/Sources/Internal/FileHeaderHandler.swift
+++ b/Generator/Sources/Internal/FileHeaderHandler.swift
@@ -14,7 +14,7 @@ struct FileHeaderHandler {
 
     static func imports(for file: FileRepresentation, imports: [String], publicImports: [String], testableImports: [String]) -> String {
         [
-            ["import Cuckoo"],
+            !publicImports.contains("Cuckoo") ? ["import Cuckoo"] : [],
             OrderedSet(file.imports.map { $0.description } + imports).values
                 .filter { !testableImports.contains($0) }
                 .map { "import \($0)" },

--- a/Generator/Sources/Internal/FileHeaderHandler.swift
+++ b/Generator/Sources/Internal/FileHeaderHandler.swift
@@ -12,12 +12,13 @@ struct FileHeaderHandler {
         .joined(separator: " ")
     }
 
-    static func imports(for file: FileRepresentation, imports: [String], testableImports: [String]) -> String {
+    static func imports(for file: FileRepresentation, imports: [String], publicImports: [String], testableImports: [String]) -> String {
         [
             ["import Cuckoo"],
             OrderedSet(file.imports.map { $0.description } + imports).values
                 .filter { !testableImports.contains($0) }
                 .map { "import \($0)" },
+            publicImports.map { "public import \($0)" },
             testableImports.map { "@testable import \($0)" },
         ]
         .flatMap { $0 }

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ output = "Tests/Swift/Generated/GeneratedMocks.swift"
 output = "Tests/Swift/Generated/GeneratedMocks+MyProject.swift"
 # Standard imports added to the generated file(s).
 imports = ["Foundation"]
+# Public imports if needed due to imports being internal by default from Swift 6.
+publicImports = ["ExampleModule"]
 # @testable imports if needed.
 testableImports = ["RxSwift"]
 sources = [


### PR DESCRIPTION
Due to imports being internal by default from Swift 6, it is sometimes necessary to explicitly make an import `public`. This MR introduces the ability to add public imports to generated files through the Cuckoofile.