### PR TITLE
Update contribute section in README.md to include `make init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,9 +471,10 @@ Detailed usage is available in Cuckoo tests along with DOs and DON'Ts of this Sw
 Cuckoo is open for everyone and we'd like you to help us make the best Swift mocking library. For Cuckoo development, follow these steps:
 1. Make sure you have the latest stable version of Xcode installed.
 2. Clone the **Cuckoo** repository.
-3. In terminal, run `make` at the root of the cloned **Cuckoo** repository, this will generate the project, install dependencies, and open the project in Xcode.
-4. Select any scheme of `Cuckoo-iOS`, `Cuckoo-tvOS`, or `Cuckoo-macOS` and verify by running the tests (⌘+U).
-5. Peek around or file a pull request with your changes.
+3. **For the initial setup**, open a terminal and run `make init` at the root of the cloned **Cuckoo** repository. This will install necessary tools (including Tuist if not already installed), generate the project, install dependencies, and open it in Xcode.
+4. **For subsequent usage or when switching branches**, run `make` at the root of the cloned **Cuckoo** repository. This will generate the project, install dependencies, and open it in Xcode.
+5. Select any scheme of `Cuckoo-iOS`, `Cuckoo-tvOS`, or `Cuckoo-macOS` and verify by running the tests (⌘+U).
+6. Peek around or file a pull request with your changes.
 
 **NOTE**: Make sure to run `make` again whenever you checkout another branch, the project utilizes [Tuist](https://github.com/tuist/tuist) for project generation.
 


### PR DESCRIPTION
This PR updates the “Contribute” section in the README.md to include instructions for using `make init` during the initial setup.

## Why this change is necessary

The current README.md does not mention the `make init` command, which is required for the first-time setup. Adding this information helps new contributors set up the project correctly without confusion.

## What this PR does

Adds a step to use `make init` for the initial setup in the “Contribute” section.

## Testing

N/A – This is a documentation-only update.