### PR TITLE
Enable Library Evolution Mode for Source

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,10 @@ let package = Package(
         .target(
             name: "Cuckoo",
             dependencies: ["OCMockWrapper"],
-            path: "Source"
+            path: "Source",
+            swiftSettings: [
+                .unsafeFlags(["-enable-library-evolution"]),
+            ]
         ),
         .testTarget(
             name: "CuckooTests",


### PR DESCRIPTION
This PR enables **library evolution mode** for the Source target in `Package.swift` . By adding the `-enable-library-evolution` flag to `swiftSettings`, we ensure **module stability** and **binary compatibility** , allowing for smoother updates and better support for prebuilt frameworks.

## Changes:

- Added `-enable-library-evolution` to `swiftSettings` in `Package.swift` .

## Why?

- Module stability: Ensures that clients depending on this module do not need to recompile when updates are made.
- Binary compatibility: Allows distributing precompiled binaries while maintaining forward compatibility.
- Fixes a warning: When using Cuckoo in an app, the following warning appears. This change resolves that issue.:

    > Module ‘Cuckoo’ was not compiled with library evolution support; using it means binary compatibility for ‘XXX’ can’t be guaranteed

## Verification

- Applied this commit on a branch created from the 2.0.10 tag.
- Ran `$ swift build -c release` and confirmed that the release build succeeds without errors.

<details><summary>Logs</summary>
<p>

```
$ swift build -c release

warning: 'cuckoo': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/m_naruse/workspace/git/home/Cuckoo/Tests/Info.plist
warning: 'cuckoo': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/m_naruse/workspace/git/home/Cuckoo/Source/Info.plist
Building for production...
/Users/m_naruse/workspace/git/home/Cuckoo/Generator/Sources/Internal/GeneratorHelper.swift:79:75: warning: immutable value 'closure' was never used; consider replacing with '_' or removing it
 77 |         var fullString = ""
 78 |         for (index, parameter) in method.signature.parameters.enumerated() {
 79 |             if !parameter.type.containsAttribute(named: "@escaping"), let closure = parameter.type.findClosure() {
    |                                                                           `- warning: immutable value 'closure' was never used; consider replacing with '_' or removing it
 80 |                 if fullString.isEmpty {
 81 |                     fullString = "\n"

/Users/m_naruse/workspace/git/home/Cuckoo/Generator/Sources/Internal/Tokens/Capabilities/HasGenerics.swift:30:40: warning: expression implicitly coerced from 'String?' to 'Any'
28 |             "genericParameters": genericParametersString,
29 |             "genericArguments": genericArgumentsString,
30 |             "genericProtocolIdentity": genericProtocolIdentity,
   |                                        |- warning: expression implicitly coerced from 'String?' to 'Any'
   |                                        |- note: provide a default value to avoid this warning
   |                                        |- note: force-unwrap the value to avoid this warning
   |                                        `- note: explicitly cast to 'Any' with 'as Any' to silence this warning
31 |         ]
32 |         .compactMapValues { $0 }
[10/10] Compiling CuckooGenerator CuckooGeneratorError.swift
Build complete! (10.50s)
```

</p>
</details>

## Additional Note:

- The current master branch (at commit bc6bc58d471c5d87f4fb55c4eecb6be33c3e96bb , which includes “Update Tuist”) fails to build in release mode, but that issue is unrelated to this commit.
