### PR TITLE
Fix swiftlang dependencies

### DIFF
--- a/Generator/Project.swift
+++ b/Generator/Project.swift
@@ -44,8 +44,8 @@ let project = Project(
         // Any dependency changes must also be reflected in ../Package.swift.
         .package(url: "https://github.com/nvzqz/FileKit.git", .exact("6.1.0")),
         .package(url: "https://github.com/kylef/Stencil.git", .exact("0.15.1")),
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("509.0.0")),
-        .package(url: "https://github.com/apple/swift-format.git", .exact("509.0.0")),
+        .package(url: "https://github.com/swiftlang/swift-syntax", .exact("509.0.0")),
+        .package(url: "https://github.com/swiftlang/swift-format", .exact("509.0.0")),
         .package(url: "https://github.com/apple/swift-argument-parser", .exact("1.2.3")),
         .package(url: "https://github.com/LebJe/TOMLKit.git", .exact("0.5.5")),
         .package(url: "https://github.com/tuist/XcodeProj.git", .exact("8.15.0")),

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "96e7a9f6ec018e7bd1fcb7721ea959359d66a7b1adbf7c83853dcd865e25fefc",
   "pins" : [
     {
       "identity" : "aexml",
@@ -16,14 +17,6 @@
       "state" : {
         "revision" : "9006d2888025fbe893c3c396327b2fe45a8c177b",
         "version" : "6.1.0"
-      }
-    },
-    {
-      "identity" : "ocmock",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/erikdoe/ocmock.git",
-      "state" : {
-        "revision" : "2c0bfd373289f4a7716db5d6db471640f91a6507"
       }
     },
     {
@@ -83,7 +76,7 @@
     {
       "identity" : "swift-format",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-format.git",
+      "location" : "https://github.com/swiftlang/swift-format",
       "state" : {
         "revision" : "83248b4fa37919f78ffbd4650946759bcc54c2b5",
         "version" : "509.0.0"
@@ -101,7 +94,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
         "version" : "509.0.0"
@@ -126,5 +119,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -29,8 +29,8 @@ let package = Package(
         // Any dependency changes must also be reflected in Generator/Project.swift.
         .package(url: "https://github.com/nvzqz/FileKit.git", exact: "6.1.0"),
         .package(url: "https://github.com/kylef/Stencil.git", exact: "0.15.1"),
-        .package(url: "https://github.com/apple/swift-syntax.git", exact: "509.0.0"),
-        .package(url: "https://github.com/apple/swift-format.git", exact: "509.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", exact: "509.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-format", exact: "509.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", exact: "1.2.3"),
         .package(url: "https://github.com/LebJe/TOMLKit.git", exact: "0.5.5"),
         .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.15.0"),


### PR DESCRIPTION
These two were moved from the `apple` org to `swiftlang`, raising warnings when being mixed with other projects pointing to the other