### PR TITLE
Fix Path-related warnings from CuckooPluginFile

### DIFF
--- a/Generator/Plugin/File/CuckooPluginFile.swift
+++ b/Generator/Plugin/File/CuckooPluginFile.swift
@@ -21,10 +21,10 @@ struct CuckooPluginFile: BuildToolPlugin {
             .filter { $0.type == .source }
 
         return try commands(
-            sources: sources.map(\.path),
+            sources: sources.map(\.url),
             executableFactory: context.tool(named:),
-            projectDir: context.package.directory,
-            derivedSourcesDir: context.pluginWorkDirectory
+            projectDir: context.package.directoryURL,
+            derivedSourcesDir: context.pluginWorkDirectoryURL
         )
     }
 }
@@ -52,35 +52,36 @@ extension CuckooPluginFile: XcodeBuildToolPlugin {
             }
 
         return try commands(
-            sources: sources.map(\.path),
+            sources: sources.map(\.url),
             executableFactory: context.tool(named:),
-            projectDir: context.xcodeProject.directory,
-            derivedSourcesDir: context.pluginWorkDirectory
+            projectDir: context.xcodeProject.directoryURL,
+            derivedSourcesDir: context.pluginWorkDirectoryURL
         )
     }
 }
 #endif
 
 func commands(
-    sources: [Path],
+    sources: [URL],
     executableFactory: (String) throws -> PluginContext.Tool,
-    projectDir: Path,
-    derivedSourcesDir: Path
+    projectDir: URL,
+    derivedSourcesDir: URL
 ) throws -> [Command] {
-    let configurationPath = projectDir.appending("Cuckoofile.toml")
-    let output = derivedSourcesDir.appending("GeneratedMocks.swift")
+    let configurationURL = projectDir.appending(path: "Cuckoofile.toml")
+    let outputURL = derivedSourcesDir.appending(component: "GeneratedMocks.swift")
+
     return [
         .buildCommand(
             displayName: "Run Cuckoonator (single file)",
-            executable: try executableFactory("CuckooGenerator").path,
+            executable: try executableFactory("CuckooGenerator").url,
             arguments: [],
             environment: [
-                "PROJECT_DIR": projectDir,
-                "DERIVED_SOURCES_DIR": derivedSourcesDir,
-                "CUCKOO_OVERRIDE_OUTPUT": output,
+                "PROJECT_DIR": projectDir.absoluteString,
+                "DERIVED_SOURCES_DIR": derivedSourcesDir.absoluteString,
+                "CUCKOO_OVERRIDE_OUTPUT": outputURL.absoluteString,
             ],
-            inputFiles: [configurationPath] + sources,
-            outputFiles: [output]
+            inputFiles: [configurationURL] + sources,
+            outputFiles: [outputURL]
         )
     ]
 }

--- a/Generator/Plugin/File/CuckooPluginFile.swift
+++ b/Generator/Plugin/File/CuckooPluginFile.swift
@@ -76,9 +76,9 @@ func commands(
             executable: try executableFactory("CuckooGenerator").url,
             arguments: [],
             environment: [
-                "PROJECT_DIR": projectDir.absoluteString,
-                "DERIVED_SOURCES_DIR": derivedSourcesDir.absoluteString,
-                "CUCKOO_OVERRIDE_OUTPUT": outputURL.absoluteString,
+                "PROJECT_DIR": projectDir.path(),
+                "DERIVED_SOURCES_DIR": derivedSourcesDir.path(),
+                "CUCKOO_OVERRIDE_OUTPUT": outputURL.path(),
             ],
             inputFiles: [configurationURL] + sources,
             outputFiles: [outputURL]

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "f38cbd38a5f422ed370782a2b038bb3710e69f935cdd77d7a790eda493d0c297",
   "pins" : [
     {
       "identity" : "aexml",
@@ -16,14 +17,6 @@
       "state" : {
         "revision" : "9006d2888025fbe893c3c396327b2fe45a8c177b",
         "version" : "6.1.0"
-      }
-    },
-    {
-      "identity" : "ocmock",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/erikdoe/ocmock.git",
-      "state" : {
-        "revision" : "2c0bfd373289f4a7716db5d6db471640f91a6507"
       }
     },
     {
@@ -126,5 +119,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
This MR aims to address the deprecation warnings pictured below that start showing up after bumping swift-tools-version to 6.0

![Screenshot 2025-03-24 at 14 14 29](https://github.com/user-attachments/assets/dd5bae14-25a7-464a-80d7-30c73fd87d90)

It also updates Package.resolved file with changes that weren't previously commited.