### PR TITLE
Allow passing an array of values to stub

### DIFF
--- a/Source/Stubbing/StubFunction/Trait/StubFunctionThenReturnTrait.swift
+++ b/Source/Stubbing/StubFunction/Trait/StubFunctionThenReturnTrait.swift
@@ -13,8 +13,8 @@ public extension StubFunctionThenReturnTrait {
     }
 
     @discardableResult
-    func thenReturn(_ output: [OutputType]) -> Self {
-        output.forEach { output in
+    func thenReturn(inOrder outputs: [OutputType]) -> Self {
+        outputs.forEach { output in
             stub.appendAction(.returnValue(output))
         }
         return self

--- a/Source/Stubbing/StubFunction/Trait/StubFunctionThenReturnTrait.swift
+++ b/Source/Stubbing/StubFunction/Trait/StubFunctionThenReturnTrait.swift
@@ -11,4 +11,12 @@ public extension StubFunctionThenReturnTrait {
         }
         return self
     }
+
+    @discardableResult
+    func thenReturn(_ output: [OutputType]) -> Self {
+        output.forEach { output in
+            stub.appendAction(.returnValue(output))
+        }
+        return self
+    }
 }

--- a/Tests/Swift/Stubbing/StubbingTest.swift
+++ b/Tests/Swift/Stubbing/StubbingTest.swift
@@ -15,6 +15,18 @@ final class StubbingTest: XCTestCase {
         XCTAssertEqual(mock.readOnlyProperty, "c")
     }
 
+    func testReturningArray() {
+        let mock = MockTestedClass()
+        stub(mock) { mock in
+            when(mock.readOnlyProperty.get).thenReturn(["a", "b", "c"])
+        }
+
+        XCTAssertEqual(mock.readOnlyProperty, "a")
+        XCTAssertEqual(mock.readOnlyProperty, "b")
+        XCTAssertEqual(mock.readOnlyProperty, "c")
+        XCTAssertEqual(mock.readOnlyProperty, "c")
+    }
+
     func testOverrideStubWithMoreGeneralParameterMatcher() {
         let mock = MockTestedClass()
         stub(mock) { mock in

--- a/Tests/Swift/Stubbing/StubbingTest.swift
+++ b/Tests/Swift/Stubbing/StubbingTest.swift
@@ -18,7 +18,7 @@ final class StubbingTest: XCTestCase {
     func testReturningArray() {
         let mock = MockTestedClass()
         stub(mock) { mock in
-            when(mock.readOnlyProperty.get).thenReturn(["a", "b", "c"])
+            when(mock.readOnlyProperty.get).thenReturn(inOrder: ["a", "b", "c"])
         }
 
         XCTAssertEqual(mock.readOnlyProperty, "a")


### PR DESCRIPTION
As spreading an array doesn't work in Swift, I've added an extension to be able to pass an array of returned values to a stub.