### PR TITLE
Add support for typed-throws methods

### DIFF
--- a/Generator/Sources/Internal/Crawlers/Crawler.swift
+++ b/Generator/Sources/Internal/Crawlers/Crawler.swift
@@ -286,7 +286,7 @@ extension Crawler {
 
             let getAccessor = accessors.first { $0.accessorSpecifier.tokenKind == .keyword(.get) }
             effects = Variable.Effects(
-                isThrowing: getAccessor?.effectSpecifiers?.throwsSpecifier?.isPresent == true,
+                isThrowing: getAccessor?.effectSpecifiers?.throwsClause != nil,
                 isAsync: getAccessor?.effectSpecifiers?.asyncSpecifier?.isPresent == true
             )
         case .getter:
@@ -330,7 +330,7 @@ extension Crawler {
                 genericParameters: genericParameters(from: initializer.genericParameterClause?.parameters),
                 parameters: parameters,
                 asyncType: nil,
-                throwType: initializer.signature.effectSpecifiers?.throwsSpecifier.flatMap { ThrowType(rawValue: $0.filteredDescription) },
+                throwType: ThrowType(syntax: initializer.signature.effectSpecifiers?.throwsClause),
                 returnType: nil,
                 whereConstraints: genericRequirements(from: initializer.genericWhereClause?.requirements)
             ),
@@ -365,7 +365,7 @@ extension Crawler {
                 genericParameters: genericParameters(from: method.genericParameterClause?.parameters),
                 parameters: parameters,
                 asyncType: method.signature.effectSpecifiers?.asyncSpecifier.flatMap { AsyncType(rawValue: $0.filteredDescription) },
-                throwType: method.signature.effectSpecifiers?.throwsSpecifier.flatMap { ThrowType(rawValue: $0.filteredDescription) },
+                throwType: ThrowType(syntax: method.signature.effectSpecifiers?.throwsClause),
                 returnType: returnType ?? ComplexType.type("Void"),
                 whereConstraints: genericRequirements(from: method.genericWhereClause?.requirements)
             ),

--- a/Generator/Sources/Internal/Templates/MockTemplate.swift
+++ b/Generator/Sources/Internal/Templates/MockTemplate.swift
@@ -124,6 +124,7 @@ extension {{ container.parentFullyQualifiedName }} {
             "{{method.fullyQualifiedName}}",
             parameters: ({{method.parameterNames}}),
             escapingParameters: ({{method.escapingParameterNames}}),
+            {% if method.throwsOnly %}errorType: {{ method.throwTypeError }}.self,{% endif %}
             superclassCall: {%+ if container.isImplementation %}{% if method.isAsync %}await {%+ endif %}super.{{method.name}}({{method.call}}){% else %}Cuckoo.MockManager.crashOnProtocolSuperclassCall(){% endif %},
             defaultCall: {%+ if method.isAsync %}await {%+ endif %}__defaultImplStub!.{{method.name}}{%if method.isOptional %}!{%endif%}({{method.call}})
         ){{ method.parameters|closeNestedClosure }}

--- a/Generator/Sources/Internal/Templates/StubbingProxyTemplate.swift
+++ b/Generator/Sources/Internal/Templates/StubbingProxyTemplate.swift
@@ -13,7 +13,7 @@ extension Templates {
     {% for attribute in property.attributes %}
     {{ attribute }}
     {% endfor %}
-    var {{property.name}}: Cuckoo.{{ property.stubType }}<{{ container.mockName }}, {% if property.isReadOnly %}{{property.type|genericSafe}}{% else %}{{property.nonOptionalType|genericSafe}}{% endif %}> {
+    var {{property.name}}: Cuckoo.{{ property.stubType }}<{{ container.mockName }}, {% if property.isReadOnly %}{{property.type|genericSafe}}{% else %}{{property.nonOptionalType|genericSafe}}{% endif %}{% if method.isThrowing %},{{ method.throwTypeError }}{% endif %}> {
         return .init(manager: cuckoo_manager, name: "{{property.name}}")
     }
     {% if property.hasUnavailablePlatforms %}
@@ -25,7 +25,7 @@ extension Templates {
     {% for attribute in method.attributes %}
     {{ attribute }}
     {% endfor %}
-    func {{method.name|escapeReservedKeywords}}{{method.self|matchableGenericNames}}({{method.parameters|matchableParameterSignature}}) -> {{method.stubFunction}}<({{method.genericInputTypes|genericSafe}}){%if method.returnType != "Void" %}, {{method.returnType|genericSafe}}{%endif%}>{{method.self|matchableGenericWhereClause}} {
+    func {{method.name|escapeReservedKeywords}}{{method.self|matchableGenericNames}}({{method.parameters|matchableParameterSignature}}) -> {{method.stubFunction}}<({{method.genericInputTypes|genericSafe}}){%if method.returnType != "Void" %}, {{method.returnType|genericSafe}}{%endif%}{% if method.isThrowing %},{{ method.throwTypeError }}{% endif %}>{{method.self|matchableGenericWhereClause}} {
         {{method.parameters|parameterMatchers}}
         return .init(stub: cuckoo_manager.createStub(for: {{ container.mockName }}.self,
             method: "{{method.fullyQualifiedName}}",

--- a/Generator/Sources/Internal/Tokens/ComplexType.swift
+++ b/Generator/Sources/Internal/Tokens/ComplexType.swift
@@ -253,7 +253,7 @@ extension ComplexType.Closure.Effects {
         if effectSpecifiers.asyncSpecifier?.isPresent == true {
             effects.insert(.async)
         }
-        if effectSpecifiers.throwsSpecifier?.isPresent == true {
+        if effectSpecifiers.throwsClause != nil {
             effects.insert(.throws)
         }
         self = effects

--- a/Generator/Sources/Internal/Tokens/Method.swift
+++ b/Generator/Sources/Internal/Tokens/Method.swift
@@ -39,6 +39,10 @@ extension Method {
     var isThrowing: Bool {
         signature.throwType.map { $0.isThrowing || $0.isRethrowing } ?? false
     }
+    
+    var throwsOnly: Bool {
+        signature.throwType.map { $0.isThrowing } ?? false
+    }
 
     var returnType: ComplexType? {
         signature.returnType
@@ -99,7 +103,9 @@ extension Method {
             "returnType": returnType?.description ?? "",
             "isAsync": isAsync,
             "isThrowing": isThrowing,
-            "throwType": signature.throwType?.description ?? "",
+            "throwsOnly": throwsOnly,
+            "throwType": signature.throwType?.keyword ?? "",
+            "throwTypeError": signature.throwType?.type ?? "",
             "fullyQualifiedName": fullyQualifiedName,
             "call": call,
             "parameterSignature": signature.parameters.map { $0.description }.joined(separator: ", "),

--- a/Generator/Sources/Internal/Tokens/ThrowType.swift
+++ b/Generator/Sources/Internal/Tokens/ThrowType.swift
@@ -1,11 +1,16 @@
-enum ThrowType: String, CustomStringConvertible, Equatable {
-    case `throws`
+import SwiftSyntax
+
+enum ThrowType: CustomStringConvertible, Equatable {
+    case `throws`(String?)
     case `rethrows`
 
-    init?(string: String) {
-        if string.trimmed.hasPrefix(ThrowType.throws.rawValue) {
-            self = .throws
-        } else if string.trimmed.hasPrefix(ThrowType.rethrows.rawValue) {
+    init?(syntax: ThrowsClauseSyntax?) {
+        guard let syntax else { return nil }
+        let keyword = syntax.throwsSpecifier.text
+        let type: String? = syntax.type?.as(IdentifierTypeSyntax.self)?.name.text
+        if keyword.trimmed.hasPrefix("throws") {
+            self = .throws(type)
+        } else if keyword.trimmed.hasPrefix("rethrows") {
             self = .rethrows
         } else {
             return nil
@@ -13,14 +18,49 @@ enum ThrowType: String, CustomStringConvertible, Equatable {
     }
 
     var isThrowing: Bool {
-        self == .throws
+        if case .throws = self {
+            return true
+        } else {
+            return false
+        }
     }
 
     var isRethrowing: Bool {
-        self == .rethrows
+        if case .rethrows = self {
+            return true
+        } else {
+            return false
+        }
     }
 
     var description: String {
-        rawValue
+        switch self {
+        case .throws(let type):
+            if let type {
+                return "throws(\(type))"
+            } else {
+                return "throws"
+            }
+        case .rethrows:
+            return "rethrows"
+        }
+    }
+    
+    var keyword: String {
+        switch self {
+        case .throws:
+            return "throws"
+        case .rethrows:
+            return "rethrows"
+        }
+    }
+    
+    var type: String {
+        switch self {
+        case .throws(let type):
+            return type ?? "Error"
+        case .rethrows:
+            return "Error"
+        }
     }
 }

--- a/Source/MockManager.swift
+++ b/Source/MockManager.swift
@@ -50,14 +50,14 @@ public class MockManager {
         return await callRethrowsInternal(method, parameters: parameters, escapingParameters: escapingParameters, superclassCall: superclassCall, defaultCall: defaultCall)
     }
     
-    private func callRethrowsInternal<IN, OUT>(_ method: String, parameters: IN, escapingParameters: IN, superclassCall: () throws -> OUT, defaultCall: () throws -> OUT) rethrows -> OUT {
+    private func callRethrowsInternal<IN, OUT, ERROR>(_ method: String, parameters: IN, escapingParameters: IN, superclassCall: () throws(ERROR) -> OUT, defaultCall: () throws(ERROR) -> OUT) rethrows -> OUT {
         let stubCall = ConcreteStubCall(method: method, parameters: escapingParameters)
         queue.sync {
             stubCalls.append(stubCall)
             unverifiedStubCallsIndexes.append(stubCalls.count - 1)
         }
 
-        if let stub = (stubs.filter { $0.method == method }.compactMap { $0 as? ConcreteStub<IN, OUT> }.filter { $0.parameterMatchers.reduce(true) { $0 && $1.matches(parameters) } }.first) {
+        if let stub = (stubs.filter { $0.method == method }.compactMap { $0 as? ConcreteStub<IN, OUT, ERROR> }.filter { $0.parameterMatchers.reduce(true) { $0 && $1.matches(parameters) } }.first) {
             
             guard let action = queue.sync(execute: {
                 return stub.actions.count > 1 ? stub.actions.removeFirst() : stub.actions.first
@@ -90,14 +90,14 @@ public class MockManager {
         }
     }
     
-    private func callRethrowsInternal<IN, OUT>(_ method: String, parameters: IN, escapingParameters: IN, superclassCall: () async throws -> OUT, defaultCall: () async throws -> OUT) async rethrows -> OUT {
+    private func callRethrowsInternal<IN, OUT, ERROR>(_ method: String, parameters: IN, escapingParameters: IN, superclassCall: () async throws(ERROR) -> OUT, defaultCall: () async throws(ERROR) -> OUT) async rethrows -> OUT {
         let stubCall = ConcreteStubCall(method: method, parameters: escapingParameters)
         queue.sync {
             stubCalls.append(stubCall)
             unverifiedStubCallsIndexes.append(stubCalls.count - 1)
         }
 
-        if let stub = (stubs.filter { $0.method == method }.compactMap { $0 as? ConcreteStub<IN, OUT> }.filter { $0.parameterMatchers.reduce(true) { $0 && $1.matches(parameters) } }.first) {
+        if let stub = (stubs.filter { $0.method == method }.compactMap { $0 as? ConcreteStub<IN, OUT, ERROR> }.filter { $0.parameterMatchers.reduce(true) { $0 && $1.matches(parameters) } }.first) {
             
             guard let action = queue.sync(execute: {
                 return stub.actions.count > 1 ? stub.actions.removeFirst() : stub.actions.first
@@ -130,14 +130,14 @@ public class MockManager {
         }
     }
     
-    private func callThrowsInternal<IN, OUT>(_ method: String, parameters: IN, escapingParameters: IN, superclassCall: () throws -> OUT, defaultCall: () throws -> OUT) throws -> OUT {
+    private func callThrowsInternal<IN, OUT, ERROR>(_ method: String, parameters: IN, escapingParameters: IN, superclassCall: () throws(ERROR) -> OUT, defaultCall: () throws(ERROR) -> OUT) throws(ERROR) -> OUT {
         let stubCall = ConcreteStubCall(method: method, parameters: escapingParameters)
         queue.sync {
             stubCalls.append(stubCall)
             unverifiedStubCallsIndexes.append(stubCalls.count - 1)
         }
         
-        if let stub = (stubs.filter { $0.method == method }.compactMap { $0 as? ConcreteStub<IN, OUT> }.filter { $0.parameterMatchers.reduce(true) { $0 && $1.matches(parameters) } }.first) {
+        if let stub = (stubs.filter { $0.method == method }.compactMap { $0 as? ConcreteStub<IN, OUT, ERROR> }.filter { $0.parameterMatchers.reduce(true) { $0 && $1.matches(parameters) } }.first) {
             
             guard let action = queue.sync(execute: {
                 return stub.actions.count > 1 ? stub.actions.removeFirst() : stub.actions.first
@@ -166,14 +166,14 @@ public class MockManager {
         }
     }
     
-    private func callThrowsInternal<IN, OUT>(_ method: String, parameters: IN, escapingParameters: IN, superclassCall: () async throws -> OUT, defaultCall: () async throws -> OUT) async throws -> OUT {
+    private func callThrowsInternal<IN, OUT, ERROR>(_ method: String, parameters: IN, escapingParameters: IN, superclassCall: () async throws(ERROR) -> OUT, defaultCall: () async throws(ERROR) -> OUT) async throws(ERROR) -> OUT {
         let stubCall = ConcreteStubCall(method: method, parameters: escapingParameters)
         queue.sync {
             stubCalls.append(stubCall)
             unverifiedStubCallsIndexes.append(stubCalls.count - 1)
         }
         
-        if let stub = (stubs.filter { $0.method == method }.compactMap { $0 as? ConcreteStub<IN, OUT> }.filter { $0.parameterMatchers.reduce(true) { $0 && $1.matches(parameters) } }.first) {
+        if let stub = (stubs.filter { $0.method == method }.compactMap { $0 as? ConcreteStub<IN, OUT, ERROR> }.filter { $0.parameterMatchers.reduce(true) { $0 && $1.matches(parameters) } }.first) {
             
             guard let action = queue.sync(execute: {
                 return stub.actions.count > 1 ? stub.actions.removeFirst() : stub.actions.first
@@ -202,14 +202,14 @@ public class MockManager {
         }
     }
     
-    public func createStub<MOCK: ClassMock, IN, OUT>(for _: MOCK.Type, method: String, parameterMatchers: [ParameterMatcher<IN>]) -> ClassConcreteStub<IN, OUT> {
-        let stub = ClassConcreteStub<IN, OUT>(method: method, parameterMatchers: parameterMatchers)
+    public func createStub<MOCK: ClassMock, IN, OUT, ERROR>(for _: MOCK.Type, method: String, parameterMatchers: [ParameterMatcher<IN>]) -> ClassConcreteStub<IN, OUT, ERROR> {
+        let stub = ClassConcreteStub<IN, OUT, ERROR>(method: method, parameterMatchers: parameterMatchers)
         stubs.insert(stub, at: 0)
         return stub
     }
 
-    public func createStub<MOCK: ProtocolMock, IN, OUT>(for _: MOCK.Type, method: String, parameterMatchers: [ParameterMatcher<IN>]) -> ConcreteStub<IN, OUT> {
-        let stub = ConcreteStub<IN, OUT>(method: method, parameterMatchers: parameterMatchers)
+    public func createStub<MOCK: ProtocolMock, IN, OUT, ERROR>(for _: MOCK.Type, method: String, parameterMatchers: [ParameterMatcher<IN>]) -> ConcreteStub<IN, OUT, ERROR> {
+        let stub = ConcreteStub<IN, OUT, ERROR>(method: method, parameterMatchers: parameterMatchers)
         stubs.insert(stub, at: 0)
         return stub
     }
@@ -327,11 +327,11 @@ extension MockManager {
 
 extension MockManager {
     public func getterThrows<T>(_ property: String, superclassCall: @autoclosure () throws -> T, defaultCall: @autoclosure () throws -> T) throws -> T {
-        return try callThrows(getterName(property), parameters: Void(), escapingParameters: Void(), superclassCall: try superclassCall(), defaultCall: try defaultCall())
+        return try callThrows(getterName(property), parameters: Void(), escapingParameters: Void(), errorType: (Error).self, superclassCall: try superclassCall(), defaultCall: try defaultCall())
     }
 
     public func getterThrows<T>(_ property: String, superclassCall: @autoclosure () async throws -> T, defaultCall: @autoclosure () async throws -> T) async throws -> T {
-        return try await callThrows(getterName(property), parameters: Void(), escapingParameters: Void(), superclassCall: try await superclassCall(), defaultCall: try await defaultCall())
+        return try await callThrows(getterName(property), parameters: Void(), escapingParameters: Void(), errorType: (Error).self, superclassCall: try await superclassCall(), defaultCall: try await defaultCall())
     }
 }
 
@@ -346,11 +346,11 @@ extension MockManager {
 }
 
 extension MockManager {
-    public func callThrows<IN, OUT>(_ method: String, parameters: IN, escapingParameters: IN, superclassCall: @autoclosure () throws -> OUT, defaultCall: @autoclosure () throws -> OUT) throws -> OUT {
+    public func callThrows<IN, OUT, ERROR>(_ method: String, parameters: IN, escapingParameters: IN, errorType: ERROR.Type, superclassCall: @autoclosure () throws(ERROR) -> OUT, defaultCall: @autoclosure () throws(ERROR) -> OUT) throws(ERROR) -> OUT {
         return try callThrowsInternal(method, parameters: parameters, escapingParameters: escapingParameters, superclassCall: superclassCall, defaultCall: defaultCall)
     }
     
-    public func callThrows<IN, OUT>(_ method: String, parameters: IN, escapingParameters: IN, superclassCall: @autoclosure () async throws -> OUT, defaultCall: @autoclosure () async throws -> OUT) async throws -> OUT {
+    public func callThrows<IN, OUT, ERROR>(_ method: String, parameters: IN, escapingParameters: IN, errorType: ERROR.Type, superclassCall: @autoclosure () async throws(ERROR) -> OUT, defaultCall: @autoclosure () async throws(ERROR) -> OUT) async throws(ERROR) -> OUT {
         return try await callThrowsInternal(method, parameters: parameters, escapingParameters: escapingParameters, superclassCall: superclassCall, defaultCall: defaultCall)
     }
 }

--- a/Source/Stubbing/Stub.swift
+++ b/Source/Stubbing/Stub.swift
@@ -2,19 +2,19 @@ public protocol Stub {
     var method: String { get }
 }
 
-public class ConcreteStub<IN, OUT>: Stub {
+public class ConcreteStub<IN, OUT, ERROR>: Stub {
     public let method: String
     let parameterMatchers: [ParameterMatcher<IN>]
-    var actions: [StubAction<IN, OUT>] = []
+    var actions: [StubAction<IN, OUT, ERROR>] = []
     
     init(method: String, parameterMatchers: [ParameterMatcher<IN>]) {
         self.method = method
         self.parameterMatchers = parameterMatchers
     }
     
-    func appendAction(_ action: StubAction<IN, OUT>) {
+    func appendAction(_ action: StubAction<IN, OUT, ERROR>) {
         actions.append(action)
     }
 }
 
-public class ClassConcreteStub<IN, OUT>: ConcreteStub<IN, OUT> { }
+public class ClassConcreteStub<IN, OUT, ERROR>: ConcreteStub<IN, OUT, ERROR> { }

--- a/Source/Stubbing/StubAction.swift
+++ b/Source/Stubbing/StubAction.swift
@@ -1,6 +1,6 @@
-enum StubAction<IN, OUT> {
-    case callImplementation((IN) throws -> OUT)
+enum StubAction<IN, OUT, ERROR> {
+    case callImplementation((IN) throws(ERROR) -> OUT)
     case returnValue(OUT)
-    case throwError(Error)
+    case throwError(ERROR)
     case callRealImplementation
 }

--- a/Source/Stubbing/StubFunction/StubFunction.swift
+++ b/Source/Stubbing/StubFunction/StubFunction.swift
@@ -2,17 +2,17 @@ public protocol StubFunction: StubFunctionThenTrait, StubFunctionThenReturnTrait
 }
 
 public struct ProtocolStubFunction<IN, OUT>: StubFunction {
-    public let stub: ConcreteStub<IN, OUT>
+    public let stub: ConcreteStub<IN, OUT, Never>
 
-    public init(stub: ConcreteStub<IN, OUT>) {
+    public init(stub: ConcreteStub<IN, OUT, Never>) {
         self.stub = stub
     }
 }
 
 public struct ClassStubFunction<IN, OUT>: StubFunction, StubFunctionThenCallRealImplementationTrait {
-    public let stub: ConcreteStub<IN, OUT>
+    public let stub: ConcreteStub<IN, OUT, Never>
 
-    public init(stub: ClassConcreteStub<IN, OUT>) {
+    public init(stub: ClassConcreteStub<IN, OUT, Never>) {
         self.stub = stub
     }
 }

--- a/Source/Stubbing/StubFunction/StubNoReturnFunction.swift
+++ b/Source/Stubbing/StubFunction/StubNoReturnFunction.swift
@@ -2,17 +2,17 @@ public protocol StubNoReturnFunction: StubFunctionThenTrait, StubFunctionThenDoN
 }
 
 public struct ProtocolStubNoReturnFunction<IN>: StubNoReturnFunction {
-    public let stub: ConcreteStub<IN, Void>
+    public let stub: ConcreteStub<IN, Void, Never>
     
-    public init(stub: ConcreteStub<IN, Void>) {
+    public init(stub: ConcreteStub<IN, Void, Never>) {
         self.stub = stub
     }
 }
 
 public struct ClassStubNoReturnFunction<IN>: StubNoReturnFunction, StubFunctionThenCallRealImplementationTrait {
-    public let stub: ConcreteStub<IN, Void>
+    public let stub: ConcreteStub<IN, Void, Never>
 
-    public init(stub: ClassConcreteStub<IN, Void>) {
+    public init(stub: ClassConcreteStub<IN, Void, Never>) {
         self.stub = stub
     }
 }

--- a/Source/Stubbing/StubFunction/StubNoReturnThrowingFunction.swift
+++ b/Source/Stubbing/StubFunction/StubNoReturnThrowingFunction.swift
@@ -1,18 +1,18 @@
 public protocol StubNoReturnThrowingFunction: StubFunctionThenTrait, StubFunctionThenDoNothingTrait, StubFunctionThenThrowTrait, StubFunctionThenThrowingTrait {
 }
 
-public struct ProtocolStubNoReturnThrowingFunction<IN>: StubNoReturnThrowingFunction {
-    public let stub: ConcreteStub<IN, Void>
+public struct ProtocolStubNoReturnThrowingFunction<IN, ERROR: Error>: StubNoReturnThrowingFunction {
+    public let stub: ConcreteStub<IN, Void, ERROR>
 
-    public init(stub: ConcreteStub<IN, Void>) {
+    public init(stub: ConcreteStub<IN, Void, ERROR>) {
         self.stub = stub
     }
 }
 
-public struct ClassStubNoReturnThrowingFunction<IN>: StubNoReturnThrowingFunction, StubFunctionThenCallRealImplementationTrait {
-    public let stub: ConcreteStub<IN, Void>
+public struct ClassStubNoReturnThrowingFunction<IN, ERROR: Error>: StubNoReturnThrowingFunction, StubFunctionThenCallRealImplementationTrait {
+    public let stub: ConcreteStub<IN, Void, ERROR>
 
-    public init(stub: ClassConcreteStub<IN, Void>) {
+    public init(stub: ClassConcreteStub<IN, Void, ERROR>) {
         self.stub = stub
     }
 }

--- a/Source/Stubbing/StubFunction/StubThrowingFunction.swift
+++ b/Source/Stubbing/StubFunction/StubThrowingFunction.swift
@@ -1,18 +1,18 @@
 public protocol StubThrowingFunction: StubFunctionThenTrait, StubFunctionThenReturnTrait, StubFunctionThenThrowTrait, StubFunctionThenThrowingTrait {
 }
 
-public struct ProtocolStubThrowingFunction<IN, OUT>: StubThrowingFunction {
-    public let stub: ConcreteStub<IN, OUT>
+public struct ProtocolStubThrowingFunction<IN, OUT, ERROR: Error>: StubThrowingFunction {
+    public let stub: ConcreteStub<IN, OUT, ERROR>
 
-    public init(stub: ConcreteStub<IN, OUT>) {
+    public init(stub: ConcreteStub<IN, OUT, ERROR>) {
         self.stub = stub
     }
 }
 
-public struct ClassStubThrowingFunction<IN, OUT>: StubThrowingFunction, StubFunctionThenCallRealImplementationTrait {
-    public let stub: ConcreteStub<IN, OUT>
+public struct ClassStubThrowingFunction<IN, OUT, ERROR: Error>: StubThrowingFunction, StubFunctionThenCallRealImplementationTrait {
+    public let stub: ConcreteStub<IN, OUT, ERROR>
 
-    public init(stub: ClassConcreteStub<IN, OUT>) {
+    public init(stub: ClassConcreteStub<IN, OUT, ERROR>) {
         self.stub = stub
     }
 }

--- a/Source/Stubbing/StubFunction/Trait/BaseStubFunctionTrait.swift
+++ b/Source/Stubbing/StubFunction/Trait/BaseStubFunctionTrait.swift
@@ -1,6 +1,7 @@
 public protocol BaseStubFunctionTrait {
     associatedtype InputType
     associatedtype OutputType
+    associatedtype ErrorType: Error
     
-    var stub: ConcreteStub<InputType, OutputType> { get }
+    var stub: ConcreteStub<InputType, OutputType, ErrorType> { get }
 }

--- a/Source/Stubbing/StubFunction/Trait/StubFunctionThenThrowTrait.swift
+++ b/Source/Stubbing/StubFunction/Trait/StubFunctionThenThrowTrait.swift
@@ -1,11 +1,11 @@
 public protocol StubFunctionThenThrowTrait: BaseStubFunctionTrait {
     /// Throws `error` when invoked.
-    func thenThrow(_ error: Error, _ errors: Error...) -> Self
+    func thenThrow(_ error: ErrorType, _ errors: ErrorType...) -> Self
 }
 
 public extension StubFunctionThenThrowTrait {
     @discardableResult
-    func thenThrow(_ error: Error, _ errors: Error...) -> Self {
+    func thenThrow(_ error: ErrorType, _ errors: ErrorType...) -> Self {
         ([error] + errors).forEach { error in
             stub.appendAction(.throwError(error))
         }

--- a/Source/Stubbing/StubFunction/Trait/StubFunctionThenThrowingTrait.swift
+++ b/Source/Stubbing/StubFunction/Trait/StubFunctionThenThrowingTrait.swift
@@ -1,11 +1,11 @@
 public protocol StubFunctionThenThrowingTrait: BaseStubFunctionTrait {
     /// Invokes throwing `implementation` when invoked.
-    func then(_ implementation: @escaping (InputType) throws -> OutputType) -> Self
+    func then(_ implementation: @escaping (InputType) throws(ErrorType) -> OutputType) -> Self
 }
 
 public extension StubFunctionThenThrowingTrait {
     @discardableResult
-    func then(_ implementation: @escaping (InputType) throws -> OutputType) -> Self {
+    func then(_ implementation: @escaping (InputType) throws(ErrorType) -> OutputType) -> Self {
         stub.appendAction(.callImplementation(implementation))
         return self
     }

--- a/Source/Stubbing/ToBeStubbedProperty/ToBeStubbedThrowingProperty.swift
+++ b/Source/Stubbing/ToBeStubbedProperty/ToBeStubbedThrowingProperty.swift
@@ -8,7 +8,7 @@ public struct ProtocolToBeStubbedThrowingProperty<MOCK: ProtocolMock, T>: ToBeSt
     private let manager: MockManager
     private let name: String
 
-    public var get: ProtocolStubThrowingFunction<Void, T> {
+    public var get: ProtocolStubThrowingFunction<Void, T, Error> {
         ProtocolStubThrowingFunction(
             stub: manager.createStub(
                 for: MOCK.self,
@@ -28,7 +28,7 @@ public struct ClassToBeStubbedThrowingProperty<MOCK: ClassMock, T>: ToBeStubbedT
     private let manager: MockManager
     private let name: String
 
-    public var get: ClassStubThrowingFunction<Void, T> {
+    public var get: ClassStubThrowingFunction<Void, T, Error> {
         ClassStubThrowingFunction(
             stub: manager.createStub(
                 for: MOCK.self,

--- a/Tests/Swift/Source/ClassWithTypedThrows.swift
+++ b/Tests/Swift/Source/ClassWithTypedThrows.swift
@@ -1,0 +1,9 @@
+struct StubError: Error {}
+
+class ClassWithTypedThrows {
+    func typedThrows() throws(StubError) -> Int? {
+        return nil
+    }
+
+    func genericWithTypedThrows<T>(_ value: T) throws(StubError) {}
+}


### PR DESCRIPTION
Add support for typed-throws methods [520](https://github.com/Brightify/Cuckoo/issues/520).

Allow to use new Swift 6 syntax:
```swift
protocol Foo {
    func bar() throws(CustomError)
}
```

Note that this PR doesn't add support for typed-throws properties. 

## Tests

- ✅ unit tests run
- ✅ add new tests for new feature