### PR TITLE
Bump maximum version of SwiftSyntax to 602.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "562183fb40df2b47a4079c4f8b0c34f450fe08944ac993f9c2681f93348a36d0",
+  "originHash" : "08253ad95e06fd2ddea0a7079824be964ff9c20b5ed3cb6537147ae01ccffd00",
   "pins" : [
     {
       "identity" : "aexml",
@@ -62,33 +62,6 @@
       "state" : {
         "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
         "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "swift-cmark",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-cmark.git",
-      "state" : {
-        "revision" : "b022b08312decdc46585e0b3440d97f6f22ef703",
-        "version" : "0.6.0"
-      }
-    },
-    {
-      "identity" : "swift-format",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-format",
-      "state" : {
-        "revision" : "ffbb3225ffda37b62c7283c70e87e8bc7e8e202a",
-        "version" : "601.0.0"
-      }
-    },
-    {
-      "identity" : "swift-markdown",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-markdown.git",
-      "state" : {
-        "revision" : "ea79e83c8744d2b50b0dc2d5bbd1e857e1253bf9",
-        "version" : "0.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         // Any dependency changes must also be reflected in Generator/Project.swift.
         .package(url: "https://github.com/nvzqz/FileKit.git", from: "6.1.0"),
         .package(url: "https://github.com/kylef/Stencil.git", from: "0.15.1"),
-        .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"603.0.0"),
         // .package(url: "https://github.com/swiftlang/swift-format", "509.0.0"..<"602.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.3"),
         .package(url: "https://github.com/LebJe/TOMLKit.git", from: "0.5.5"),


### PR DESCRIPTION
Bump maximum version of SwiftSyntax to 602.0.0 to support Swift 6.2 toolchain