### PR TITLE
Fix typed-throws compilation issue with Swift 6.2

### DIFF
--- a/Source/Stubbing/Stub.swift
+++ b/Source/Stubbing/Stub.swift
@@ -2,7 +2,7 @@ public protocol Stub {
     var method: String { get }
 }
 
-public class ConcreteStub<IN, OUT, ERROR>: Stub {
+public class ConcreteStub<IN, OUT, ERROR: Error>: Stub {
     public let method: String
     let parameterMatchers: [ParameterMatcher<IN>]
     var actions: [StubAction<IN, OUT, ERROR>] = []
@@ -17,4 +17,4 @@ public class ConcreteStub<IN, OUT, ERROR>: Stub {
     }
 }
 
-public class ClassConcreteStub<IN, OUT, ERROR>: ConcreteStub<IN, OUT, ERROR> { }
+public class ClassConcreteStub<IN, OUT, ERROR: Error>: ConcreteStub<IN, OUT, ERROR> { }

--- a/Source/Stubbing/StubAction.swift
+++ b/Source/Stubbing/StubAction.swift
@@ -1,4 +1,4 @@
-enum StubAction<IN, OUT, ERROR> {
+enum StubAction<IN, OUT, ERROR: Error> {
     case callImplementation((IN) throws(ERROR) -> OUT)
     case returnValue(OUT)
     case throwError(ERROR)

--- a/Tests/Swift/Source/TestedClass.swift
+++ b/Tests/Swift/Source/TestedClass.swift
@@ -214,6 +214,8 @@ class TestedClass {
     func withReservedKeywords(for: String, in: String) -> String {
         "hello"
     }
+    
+    func withTypedThrows() throws(NSError) {}
 
     func callingCountCharactersMethodWithHello() -> Int {
         return count(characters: "Hello")

--- a/Tests/Swift/Stubbing/StubThrowingFunctionTest.swift
+++ b/Tests/Swift/Stubbing/StubThrowingFunctionTest.swift
@@ -66,6 +66,14 @@ final class StubThrowingFunctionTest: XCTestCase {
 
         XCTAssertTrue(catched)
     }
+    
+    func testTypedThrowsThenTypedError() {
+        let mock = MockTestedClass()
+        stub(mock) { mock in
+            when(mock.withTypedThrows())
+                .thenThrow(NSError())
+        }
+    }
 
     private enum TestError: Error {
         case unknown


### PR DESCRIPTION
Newly added typed-throws support doesn't compile with Swift 6.2 for some reason. 
Adding Error protocol requirement on generic ERROR type fixes the issue.

Add a Stub test to assert usage of typed `thenThrow` method.

## Tests
- Xcode 16.4, swift 6.1 ✅
- Xcode 26, swift 6.2 ✅