### PR TITLE
Update XcodeProj to 9.x

### DIFF
--- a/.package.resolved
+++ b/.package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tadija/AEXML.git",
       "state" : {
-        "revision" : "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
-        "version" : "4.6.1"
+        "revision" : "db806756c989760b35108146381535aec231092b",
+        "version" : "4.7.0"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "3797181813ee963fe305d939232bc576d23ddbb0",
-        "version" : "8.15.0"
+        "revision" : "9799bb429fda8e360f4c535af1716bebc89fb235",
+        "version" : "9.4.3"
       }
     }
   ],

--- a/Generator/Generator.xcodeproj/project.pbxproj
+++ b/Generator/Generator.xcodeproj/project.pbxproj
@@ -944,7 +944,7 @@
 			repositoryURL = "https://github.com/tuist/XcodeProj.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 8.15.0;
+				minimumVersion = 9.0.0;
 			};
 		};
 		654FDF5DDCA8E00AB30C627C /* XCRemoteSwiftPackageReference "TOMLKit" */ = {

--- a/Generator/Generator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Generator/Generator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "b1caa062d4aaab3e3d2bed5fe0ac5f8ce9bf84f4",
-        "version" : "8.27.7"
+        "revision" : "9799bb429fda8e360f4c535af1716bebc89fb235",
+        "version" : "9.4.3"
       }
     }
   ],

--- a/Generator/Project.swift
+++ b/Generator/Project.swift
@@ -48,7 +48,7 @@ let project = Project(
         .package(url: "https://github.com/swiftlang/swift-format", "509.0.0"..<"602.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.3"),
         .package(url: "https://github.com/LebJe/TOMLKit.git", from: "0.5.5"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", from: "8.15.0"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", from: "9.0.0"),
         .package(url: "https://github.com/onevcat/Rainbow", from: "4.0.1"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         // .package(url: "https://github.com/swiftlang/swift-format", "509.0.0"..<"602.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.3"),
         .package(url: "https://github.com/LebJe/TOMLKit.git", from: "0.5.5"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", from: "8.15.0"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", from: "9.0.0"),
         .package(url: "https://github.com/onevcat/Rainbow", from: "4.0.1"),
     ],
     targets: [


### PR DESCRIPTION
Does what the title says 😅 

There weren't any changes to the parts of XcodeProj used in Cuckoo.

If you'd like, I could update this similar to how we have swift-syntax defined (using a version range rather than `from`) but I feel like that's probably overkill for anything except swift-syntax/swift-format