### PR TITLE
fix(podspec): remove sub.source_files = []

### DIFF
--- a/Cuckoo.podspec
+++ b/Cuckoo.podspec
@@ -38,7 +38,6 @@ Pod::Spec.new do |s|
 
   s.subspec 'OCMock' do |sub|
     sub.source_files = 'OCMock/**/*.{h,m,swift}'
-    sub.source_files = []
     sub.dependency 'Cuckoo/Swift'
     sub.dependency 'OCMock', '3.9.3'
   end


### PR DESCRIPTION
remove sub.source_files = [] which caused OCMock subspec to fetch no source files