### PR TITLE
Expose CuckooGenerator as executable product

### DIFF
--- a/Generator/Sources/Internal/Helpers/Async+convenience.swift
+++ b/Generator/Sources/Internal/Helpers/Async+convenience.swift
@@ -47,7 +47,7 @@ extension Sequence where Element: Sendable {
         // A task group automatically waits for all of its
         // sub-tasks to complete, while also performing those
         // tasks in parallel:
-        if #available(macOS 14.0, *) {
+        if #available(macOS 14.0, iOS 17.0, *) {
             await withDiscardingTaskGroup { group in
                 for element in self {
                     group.addTask {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "56435a5ee34a0880cd334d8501491902482701af75e23031558e8d751a0ff571",
+  "originHash" : "d74f646b284cb356ac99bcf2d5948e8a933f89b92eccac29090027d4bdc94411",
   "pins" : [
     {
       "identity" : "aexml",
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "77ee0721798186f71b7ee8f7e29be8495d28360f",
-        "version" : "9.9.0"
+        "revision" : "eb001108f64467b0cc7e8cbf90b3b4aaa1822cbb",
+        "version" : "9.14.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,10 @@ let package = Package(
             name: "Cuckoo",
             targets: ["Cuckoo"]
         ),
+        .executable(
+            name: "CuckooGenerator",
+            targets: ["CuckooGenerator"]
+        ),
         .plugin(
             name: "CuckooPluginSingleFile",
             targets: ["CuckooPluginSingleFile"]

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     platforms: [
         .iOS("13.0"),
         .tvOS("13.0"),
-        .macOS("10.15"),
+        .macOS("11.0"),
         .watchOS("8.0"),
     ],
     products: [
@@ -41,7 +41,7 @@ let package = Package(
         // .package(url: "https://github.com/swiftlang/swift-format", "600.1.0"..<"603.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", exact: "1.7.0"),
         .package(url: "https://github.com/LebJe/TOMLKit", exact: "0.6.0"),
-        .package(url: "https://github.com/tuist/XcodeProj", exact: "9.9.0"),
+        .package(url: "https://github.com/tuist/XcodeProj", exact: "9.14.0"),
         .package(url: "https://github.com/onevcat/Rainbow", exact: "4.2.1"),
     ],
     targets: [


### PR DESCRIPTION
## Summary
Exposes `CuckooGenerator` as a public executable product so downstream consumers can build
custom build plugins on top of it. In order to do so, `XcodeProj` must be bumped to 9.13.0+. 

## Changes

| File | Change |
|---|---|
| `Package.swift` | Adds `.executable(name: "CuckooGenerator", targets: ["CuckooGenerator"])` product; bumps `XcodeProj` `9.9.0` → `9.14.0`; raises `.macOS` platform floor `10.15` → `11.0` |
| `Package.resolved` | Re-resolved pin for `XcodeProj` → `9.14.0` (`eb001108...`), `originHash` regenerated |
| `Generator/Sources/Internal/Helpers/Async+convenience.swift` | `#available(macOS 14.0, *)` → `#available(macOS 14.0, iOS 17.0, *)` — adds the `iOS` branch needed now that `CuckooGenerator` can be built for iOS as a side effect of the executable product |

## Verification
- `swift package resolve` — resolves cleanly against the new `XcodeProj` version.
- `swift build` — full build succeeds (`CuckooGenerator` and `CuckooGenerator-tool` link successfully).

## Things to call out to reviewers
- **Breaking for consumers still on macOS 10.15**: the platform bump to macOS 11.0 is required
  by `XcodeProj` 9.14.0 itself (its manifest declares 11.0 as its floor), not a choice made here.
  Worth a one-line mention in the PR body since it's a compatibility change, not just a version bump.
- **iOS compilation of `CuckooGenerator`**: per the earlier PR discussion, exposing this as an
  executable product means it now also compiles for iOS as a side effect of the platform list,
  even though it's really meant for host-side (macOS) tooling use. Nothing in `Package.swift`
  stops an app target from linking it. Confirm the README documents that this is intended for
  build-tool/plugin use only, not for shipping inside an app target.
- No behavior changes to existing `Cuckoo`/mocking runtime code — this is purely packaging +
  dependency surface.