### PR TITLE
Add CuckooPluginModular for per-module mock generation

### DIFF
--- a/Generator/Plugin/Modular/CuckooPluginModular.swift
+++ b/Generator/Plugin/Modular/CuckooPluginModular.swift
@@ -2,7 +2,7 @@ import Foundation
 import PackagePlugin
 
 @main
-struct CuckooPluginPerModule: BuildToolPlugin {
+struct CuckooPluginModular: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
         let sourceModules: [SourceModule] = target.dependencies
             .flatMap { dependency in
@@ -49,7 +49,7 @@ struct CuckooPluginPerModule: BuildToolPlugin {
 #if canImport(XcodeProjectPlugin)
 import XcodeProjectPlugin
 
-extension CuckooPluginPerModule: XcodeBuildToolPlugin {
+extension CuckooPluginModular: XcodeBuildToolPlugin {
     func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
         let sourceModules: [SourceModule] = target.dependencies
             .flatMap { dependency in

--- a/Generator/Plugin/Modular/CuckooPluginModular.swift
+++ b/Generator/Plugin/Modular/CuckooPluginModular.swift
@@ -37,7 +37,6 @@ struct CuckooPluginModular: BuildToolPlugin {
         }
 
         return try commandsPerModule(
-            targetName: target.name,
             sourceModules: allSourceModules,
             executableFactory: context.tool(named:),
             projectDir: context.package.directoryURL,
@@ -86,7 +85,6 @@ extension CuckooPluginModular: XcodeBuildToolPlugin {
         allSourceModules.append(selfModule)
 
         return try commandsPerModule(
-            targetName: target.displayName,
             sourceModules: allSourceModules,
             executableFactory: context.tool(named:),
             projectDir: context.xcodeProject.directoryURL,
@@ -102,7 +100,6 @@ struct SourceModule {
 }
 
 private func commandsPerModule(
-    targetName: String,
     sourceModules: [SourceModule],
     executableFactory: (String) throws -> PluginContext.Tool,
     projectDir: URL,
@@ -123,7 +120,6 @@ private func commandsPerModule(
                 "DERIVED_SOURCES_DIR": derivedSourcesDir.path(),
                 "CUCKOO_OVERRIDE_OUTPUT": outputURL.path(),
                 "CUCKOO_MODULE_NAME": sourceModule.name,
-                "CUCKOO_COMPOUND_MODULE_NAME": "\(targetName)/\(sourceModule.name)",
             ],
             inputFiles: [configurationURL] + sourceModule.sources,
             outputFiles: [outputURL]

--- a/Generator/Plugin/PerModule/CuckooPluginPerModule.swift
+++ b/Generator/Plugin/PerModule/CuckooPluginPerModule.swift
@@ -24,8 +24,21 @@ struct CuckooPluginPerModule: BuildToolPlugin {
                 )
             }
 
+        // For test targets, also emit a build command keyed by the test target's own name.
+        // This allows Cuckoofile.toml to have a [modules.TestTargetName] entry that mocks
+        // specific files from any dependency, independently of per-dependency mock generation.
+        var allSourceModules = sourceModules
+        if let testTarget = target as? SourceModuleTarget, testTarget.kind == .test {
+            let selfModule = SourceModule(
+                name: target.name,
+                sources: sourceModules.flatMap(\.sources)
+            )
+            allSourceModules.append(selfModule)
+        }
+
         return try commandsPerModule(
-            sourceModules: sourceModules,
+            targetName: target.name,
+            sourceModules: allSourceModules,
             executableFactory: context.tool(named:),
             projectDir: context.package.directoryURL,
             derivedSourcesDir: context.pluginWorkDirectoryURL
@@ -62,8 +75,19 @@ extension CuckooPluginPerModule: XcodeBuildToolPlugin {
                 }
             }
 
+        // For test targets, also emit a build command keyed by the test target's own name.
+        // This allows Cuckoofile.toml to have a [modules.TestTargetName] entry that mocks
+        // specific files from any dependency, independently of per-dependency mock generation.
+        var allSourceModules = sourceModules
+        let selfModule = SourceModule(
+            name: target.displayName,
+            sources: sourceModules.flatMap(\.sources)
+        )
+        allSourceModules.append(selfModule)
+
         return try commandsPerModule(
-            sourceModules: sourceModules,
+            targetName: target.displayName,
+            sourceModules: allSourceModules,
             executableFactory: context.tool(named:),
             projectDir: context.xcodeProject.directoryURL,
             derivedSourcesDir: context.pluginWorkDirectoryURL
@@ -78,6 +102,7 @@ struct SourceModule {
 }
 
 private func commandsPerModule(
+    targetName: String,
     sourceModules: [SourceModule],
     executableFactory: (String) throws -> PluginContext.Tool,
     projectDir: URL,
@@ -98,6 +123,7 @@ private func commandsPerModule(
                 "DERIVED_SOURCES_DIR": derivedSourcesDir.path(),
                 "CUCKOO_OVERRIDE_OUTPUT": outputURL.path(),
                 "CUCKOO_MODULE_NAME": sourceModule.name,
+                "CUCKOO_COMPOUND_MODULE_NAME": "\(targetName)/\(sourceModule.name)",
             ],
             inputFiles: [configurationURL] + sourceModule.sources,
             outputFiles: [outputURL]

--- a/Generator/Plugin/PerModule/CuckooPluginPerModule.swift
+++ b/Generator/Plugin/PerModule/CuckooPluginPerModule.swift
@@ -1,0 +1,106 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct CuckooPluginPerModule: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+        let sourceModules: [SourceModule] = target.dependencies
+            .flatMap { dependency in
+                switch dependency {
+                case .product(let product):
+                    return product.targets
+                case .target(let target):
+                    return [target]
+                @unknown default:
+                    return []
+                }
+            }
+            .compactMap { $0 as? SourceModuleTarget }
+            .filter { $0.kind == ModuleKind.generic && $0.moduleName != "Cuckoo" }
+            .map { module in
+                SourceModule(
+                    name: module.moduleName,
+                    sources: module.sourceFiles.filter { $0.type == .source }.map(\.url)
+                )
+            }
+
+        return try commandsPerModule(
+            sourceModules: sourceModules,
+            executableFactory: context.tool(named:),
+            projectDir: context.package.directoryURL,
+            derivedSourcesDir: context.pluginWorkDirectoryURL
+        )
+    }
+}
+
+#if canImport(XcodeProjectPlugin)
+import XcodeProjectPlugin
+
+extension CuckooPluginPerModule: XcodeBuildToolPlugin {
+    func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
+        let sourceModules: [SourceModule] = target.dependencies
+            .flatMap { dependency in
+                switch dependency {
+                case .product(let product):
+                    return product.targets
+                        .compactMap { $0 as? SwiftSourceModuleTarget }
+                        .filter { $0.kind == ModuleKind.generic && $0.moduleName != "Cuckoo" }
+                        .map { module in
+                            SourceModule(
+                                name: module.moduleName,
+                                sources: module.sourceFiles.filter { $0.type == .source }.map(\.url)
+                            )
+                        }
+                case .target(let target):
+                    guard target.displayName != "Cuckoo" else { return [] }
+                    return [SourceModule(
+                        name: target.displayName,
+                        sources: target.inputFiles.filter { $0.type == .source }.map(\.url)
+                    )]
+                @unknown default:
+                    return []
+                }
+            }
+
+        return try commandsPerModule(
+            sourceModules: sourceModules,
+            executableFactory: context.tool(named:),
+            projectDir: context.xcodeProject.directoryURL,
+            derivedSourcesDir: context.pluginWorkDirectoryURL
+        )
+    }
+}
+#endif
+
+struct SourceModule {
+    let name: String
+    let sources: [URL]
+}
+
+private func commandsPerModule(
+    sourceModules: [SourceModule],
+    executableFactory: (String) throws -> PluginContext.Tool,
+    projectDir: URL,
+    derivedSourcesDir: URL
+) throws -> [Command] {
+    let configurationURL = projectDir.appending(path: "Cuckoofile.toml")
+    let executable = try executableFactory("CuckooGenerator").url
+
+    return sourceModules.map { sourceModule in
+        let outputURL = derivedSourcesDir.appending(component: "GeneratedMocks_\(sourceModule.name).swift")
+
+        return .buildCommand(
+            displayName: "Run Cuckoonator for \(sourceModule.name)",
+            executable: executable,
+            arguments: [],
+            environment: [
+                "PROJECT_DIR": projectDir.path(),
+                "DERIVED_SOURCES_DIR": derivedSourcesDir.path(),
+                "CUCKOO_OVERRIDE_OUTPUT": outputURL.path(),
+                "CUCKOO_MODULE_NAME": sourceModule.name,
+            ],
+            inputFiles: [configurationURL] + sourceModule.sources,
+            outputFiles: [outputURL]
+        )
+    }
+}

--- a/Generator/Sources/CLI/GenerateCommand.swift
+++ b/Generator/Sources/CLI/GenerateCommand.swift
@@ -56,11 +56,9 @@ struct GenerateCommand: AsyncParsableCommand {
         )
 
         if modules.isEmpty {
-            let compoundModuleName = ProcessInfo.processInfo.environment["CUCKOO_COMPOUND_MODULE_NAME"]
             let requestedModuleName = ProcessInfo.processInfo.environment["CUCKOO_MODULE_NAME"]
-            let effectiveName = compoundModuleName ?? requestedModuleName
-            if let effectiveName {
-                log(.info, message: "No module named '\(effectiveName)' found in Cuckoofile, skipping generation.")
+            if let requestedModuleName {
+                log(.info, message: "No module named '\(requestedModuleName)' found in Cuckoofile, skipping generation.")
             }
             if let outputPath = overriddenOutput {
                 let path = Path(outputPath, expandingTilde: true)
@@ -124,7 +122,6 @@ struct GenerateCommand: AsyncParsableCommand {
 
     func modules(configurationPath: Path, contents: String) throws -> [Module] {
         let requestedModuleName = ProcessInfo.processInfo.environment["CUCKOO_MODULE_NAME"]
-        let compoundModuleName = ProcessInfo.processInfo.environment["CUCKOO_COMPOUND_MODULE_NAME"]
 
         var errorMessages: [String] = []
         var globalOutput: String? = overriddenOutput
@@ -188,39 +185,9 @@ struct GenerateCommand: AsyncParsableCommand {
             throw GenerateError.configurationErrors(details: errorMessages)
         }
 
-        let filteredModules = filterModulesByEnvironment(
-            allModules: allModules,
-            compoundModuleName: compoundModuleName,
-            requestedModuleName: requestedModuleName
-        )
-
-        return filteredModules
-    }
-
-    /// Filter modules based on environment variables set by the plugin.
-    /// Priority: compound module name (TARGET/MODULE) > plain module name > all modules.
-    /// This allows test targets to override shared dependency mock generation.
-    private func filterModulesByEnvironment(
-        allModules: [Module],
-        compoundModuleName: String?,
-        requestedModuleName: String?
-    ) -> [Module] {
-        if let compoundModuleName {
-            let compoundMatches = allModules.filter { $0.name == compoundModuleName }
-            if !compoundMatches.isEmpty {
-                // Compound key (TARGET/MODULE) found – use it exclusively.
-                // An entry with empty sources acts as a suppressor, producing an empty output file.
-                return compoundMatches
-            } else if let requestedModuleName {
-                // No compound override – fall back to the plain module name.
-                return allModules.filter { $0.name == requestedModuleName }
-            } else {
-                return []
-            }
-        } else if let requestedModuleName {
+        if let requestedModuleName {
             return allModules.filter { $0.name == requestedModuleName }
         }
-
         return allModules
     }
 

--- a/Generator/Sources/CLI/GenerateCommand.swift
+++ b/Generator/Sources/CLI/GenerateCommand.swift
@@ -50,10 +50,28 @@ struct GenerateCommand: AsyncParsableCommand {
         overriddenOutput = ProcessInfo.processInfo.environment["CUCKOO_OVERRIDE_OUTPUT"]
         Module.overriddenOutput = overriddenOutput
 
-        let modules = try modules(
+        let requestedModuleName = ProcessInfo.processInfo.environment["CUCKOO_MODULE_NAME"]
+
+        var modules = try modules(
             configurationPath: configurationFile.path,
             contents: configurationFile.contents
         )
+
+        if let requestedModuleName {
+            modules = modules.filter { $0.name == requestedModuleName }
+            if modules.isEmpty {
+                log(.info, message: "No module named '\(requestedModuleName)' found in Cuckoofile, skipping generation.")
+                if let outputPath = overriddenOutput {
+                    let path = Path(outputPath, expandingTilde: true)
+                    try? path.parent.createDirectory(withIntermediateDirectories: true)
+                    let existing = try? String(contentsOfFile: path.rawValue, encoding: .utf8)
+                    if existing != "" {
+                        try? TextFile(path: path).write("")
+                    }
+                }
+                return
+            }
+        }
 
         // To not capture mutating self.
         let verbose = self.verbose
@@ -88,7 +106,10 @@ struct GenerateCommand: AsyncParsableCommand {
                             ?? originalFileName
                         let outputFile = TextFile(path: absoluteOutputPath + "\(fileNameWithoutExtension).swift")
                         do {
-                            try outputFile.write(generatedFile.contents)
+                            let existing = try? outputFile.read()
+                            if existing != generatedFile.contents {
+                                try outputFile.write(generatedFile.contents)
+                            }
                         } catch {
                             log(.error, message: "Failed to write to file '\(outputFile)':", error)
                         }
@@ -96,7 +117,11 @@ struct GenerateCommand: AsyncParsableCommand {
                 } else {
                     let outputFile = TextFile(path: absoluteOutputPath)
                     do {
-                        try outputFile.write(generatedFiles.map(\.contents).joined(separator: "\n\n"))
+                        let newContents = generatedFiles.map(\.contents).joined(separator: "\n\n")
+                        let existing = try? outputFile.read()
+                        if existing != newContents {
+                            try outputFile.write(newContents)
+                        }
                     } catch {
                         log(.error, message: "Failed to write to file '\(outputFile)':", error)
                     }

--- a/Generator/Sources/CLI/GenerateCommand.swift
+++ b/Generator/Sources/CLI/GenerateCommand.swift
@@ -50,34 +50,14 @@ struct GenerateCommand: AsyncParsableCommand {
         overriddenOutput = ProcessInfo.processInfo.environment["CUCKOO_OVERRIDE_OUTPUT"]
         Module.overriddenOutput = overriddenOutput
 
-        let requestedModuleName = ProcessInfo.processInfo.environment["CUCKOO_MODULE_NAME"]
-        let compoundModuleName = ProcessInfo.processInfo.environment["CUCKOO_COMPOUND_MODULE_NAME"]
-
-        let allModules = try modules(
+        let modules = try modules(
             configurationPath: configurationFile.path,
             contents: configurationFile.contents
         )
 
-        var modules: [Module]
-        if let compoundModuleName {
-            let compoundMatches = allModules.filter { $0.name == compoundModuleName }
-            if !compoundMatches.isEmpty {
-                // Compound key (TARGET/MODULE) found – use it exclusively.
-                // An entry with empty sources acts as a suppressor, producing an empty output file.
-                modules = compoundMatches
-            } else if let requestedModuleName {
-                // No compound override – fall back to the plain module name.
-                modules = allModules.filter { $0.name == requestedModuleName }
-            } else {
-                modules = []
-            }
-        } else if let requestedModuleName {
-            modules = allModules.filter { $0.name == requestedModuleName }
-        } else {
-            modules = allModules
-        }
-
         if modules.isEmpty {
+            let compoundModuleName = ProcessInfo.processInfo.environment["CUCKOO_COMPOUND_MODULE_NAME"]
+            let requestedModuleName = ProcessInfo.processInfo.environment["CUCKOO_MODULE_NAME"]
             let effectiveName = compoundModuleName ?? requestedModuleName
             if let effectiveName {
                 log(.info, message: "No module named '\(effectiveName)' found in Cuckoofile, skipping generation.")
@@ -85,10 +65,7 @@ struct GenerateCommand: AsyncParsableCommand {
             if let outputPath = overriddenOutput {
                 let path = Path(outputPath, expandingTilde: true)
                 try? path.parent.createDirectory(withIntermediateDirectories: true)
-                let existing = try? String(contentsOfFile: path.rawValue, encoding: .utf8)
-                if existing != "" {
-                    try? TextFile(path: path).write("")
-                }
+                try? TextFile(path: path).write("")
             }
             return
         }
@@ -126,10 +103,7 @@ struct GenerateCommand: AsyncParsableCommand {
                             ?? originalFileName
                         let outputFile = TextFile(path: absoluteOutputPath + "\(fileNameWithoutExtension).swift")
                         do {
-                            let existing = try? outputFile.read()
-                            if existing != generatedFile.contents {
-                                try outputFile.write(generatedFile.contents)
-                            }
+                            try outputFile.write(generatedFile.contents)
                         } catch {
                             log(.error, message: "Failed to write to file '\(outputFile)':", error)
                         }
@@ -137,11 +111,7 @@ struct GenerateCommand: AsyncParsableCommand {
                 } else {
                     let outputFile = TextFile(path: absoluteOutputPath)
                     do {
-                        let newContents = generatedFiles.map(\.contents).joined(separator: "\n\n")
-                        let existing = try? outputFile.read()
-                        if existing != newContents {
-                            try outputFile.write(newContents)
-                        }
+                        try outputFile.write(generatedFiles.map(\.contents).joined(separator: "\n\n"))
                     } catch {
                         log(.error, message: "Failed to write to file '\(outputFile)':", error)
                     }
@@ -153,9 +123,12 @@ struct GenerateCommand: AsyncParsableCommand {
     }
 
     func modules(configurationPath: Path, contents: String) throws -> [Module] {
+        let requestedModuleName = ProcessInfo.processInfo.environment["CUCKOO_MODULE_NAME"]
+        let compoundModuleName = ProcessInfo.processInfo.environment["CUCKOO_COMPOUND_MODULE_NAME"]
+
         var errorMessages: [String] = []
         var globalOutput: String? = overriddenOutput
-        var modules: [Module] = []
+        var allModules: [Module] = []
         let table = try TOMLTable(string: contents)
 
         // Sorting to make sure global properties are evaluated first to be available as fallbacks.
@@ -201,7 +174,7 @@ struct GenerateCommand: AsyncParsableCommand {
                             dto: dto
                         )
                         log(.verbose, message: "Module \(moduleName):", module)
-                        modules.append(module)
+                        allModules.append(module)
                     } catch {
                         errorMessages.append(String(describing: error))
                     }
@@ -215,7 +188,40 @@ struct GenerateCommand: AsyncParsableCommand {
             throw GenerateError.configurationErrors(details: errorMessages)
         }
 
-        return modules
+        let filteredModules = filterModulesByEnvironment(
+            allModules: allModules,
+            compoundModuleName: compoundModuleName,
+            requestedModuleName: requestedModuleName
+        )
+
+        return filteredModules
+    }
+
+    /// Filter modules based on environment variables set by the plugin.
+    /// Priority: compound module name (TARGET/MODULE) > plain module name > all modules.
+    /// This allows test targets to override shared dependency mock generation.
+    private func filterModulesByEnvironment(
+        allModules: [Module],
+        compoundModuleName: String?,
+        requestedModuleName: String?
+    ) -> [Module] {
+        if let compoundModuleName {
+            let compoundMatches = allModules.filter { $0.name == compoundModuleName }
+            if !compoundMatches.isEmpty {
+                // Compound key (TARGET/MODULE) found – use it exclusively.
+                // An entry with empty sources acts as a suppressor, producing an empty output file.
+                return compoundMatches
+            } else if let requestedModuleName {
+                // No compound override – fall back to the plain module name.
+                return allModules.filter { $0.name == requestedModuleName }
+            } else {
+                return []
+            }
+        } else if let requestedModuleName {
+            return allModules.filter { $0.name == requestedModuleName }
+        }
+
+        return allModules
     }
 
     private enum GenerateError: Error, CustomStringConvertible {

--- a/Generator/Sources/CLI/GenerateCommand.swift
+++ b/Generator/Sources/CLI/GenerateCommand.swift
@@ -51,26 +51,46 @@ struct GenerateCommand: AsyncParsableCommand {
         Module.overriddenOutput = overriddenOutput
 
         let requestedModuleName = ProcessInfo.processInfo.environment["CUCKOO_MODULE_NAME"]
+        let compoundModuleName = ProcessInfo.processInfo.environment["CUCKOO_COMPOUND_MODULE_NAME"]
 
-        var modules = try modules(
+        let allModules = try modules(
             configurationPath: configurationFile.path,
             contents: configurationFile.contents
         )
 
-        if let requestedModuleName {
-            modules = modules.filter { $0.name == requestedModuleName }
-            if modules.isEmpty {
-                log(.info, message: "No module named '\(requestedModuleName)' found in Cuckoofile, skipping generation.")
-                if let outputPath = overriddenOutput {
-                    let path = Path(outputPath, expandingTilde: true)
-                    try? path.parent.createDirectory(withIntermediateDirectories: true)
-                    let existing = try? String(contentsOfFile: path.rawValue, encoding: .utf8)
-                    if existing != "" {
-                        try? TextFile(path: path).write("")
-                    }
-                }
-                return
+        var modules: [Module]
+        if let compoundModuleName {
+            let compoundMatches = allModules.filter { $0.name == compoundModuleName }
+            if !compoundMatches.isEmpty {
+                // Compound key (TARGET/MODULE) found – use it exclusively.
+                // An entry with empty sources acts as a suppressor, producing an empty output file.
+                modules = compoundMatches
+            } else if let requestedModuleName {
+                // No compound override – fall back to the plain module name.
+                modules = allModules.filter { $0.name == requestedModuleName }
+            } else {
+                modules = []
             }
+        } else if let requestedModuleName {
+            modules = allModules.filter { $0.name == requestedModuleName }
+        } else {
+            modules = allModules
+        }
+
+        if modules.isEmpty {
+            let effectiveName = compoundModuleName ?? requestedModuleName
+            if let effectiveName {
+                log(.info, message: "No module named '\(effectiveName)' found in Cuckoofile, skipping generation.")
+            }
+            if let outputPath = overriddenOutput {
+                let path = Path(outputPath, expandingTilde: true)
+                try? path.parent.createDirectory(withIntermediateDirectories: true)
+                let existing = try? String(contentsOfFile: path.rawValue, encoding: .utf8)
+                if existing != "" {
+                    try? TextFile(path: path).write("")
+                }
+            }
+            return
         }
 
         // To not capture mutating self.

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,10 @@ let package = Package(
             name: "CuckooPluginSingleFile",
             targets: ["CuckooPluginSingleFile"]
         ),
+        .plugin(
+            name: "CuckooPluginPerModule",
+            targets: ["CuckooPluginPerModule"]
+        ),
         // FIXME: Currently unusable because Xcode doesn't allow using prebuild commands with executable targets
         // .plugin(
         //     name: "CuckooPluginIndividualFiles",
@@ -66,6 +70,12 @@ let package = Package(
             capability: .buildTool(),
             dependencies: ["CuckooGenerator"],
             path: "Generator/Plugin/File"
+        ),
+        .plugin(
+            name: "CuckooPluginPerModule",
+            capability: .buildTool(),
+            dependencies: ["CuckooGenerator"],
+            path: "Generator/Plugin/PerModule"
         ),
         // .plugin(
         //     name: "CuckooPluginIndividualFiles",

--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,8 @@ let package = Package(
             targets: ["CuckooPluginSingleFile"]
         ),
         .plugin(
-            name: "CuckooPluginPerModule",
-            targets: ["CuckooPluginPerModule"]
+            name: "CuckooPluginModular",
+            targets: ["CuckooPluginModular"]
         ),
         // FIXME: Currently unusable because Xcode doesn't allow using prebuild commands with executable targets
         // .plugin(
@@ -72,10 +72,10 @@ let package = Package(
             path: "Generator/Plugin/File"
         ),
         .plugin(
-            name: "CuckooPluginPerModule",
+            name: "CuckooPluginModular",
             capability: .buildTool(),
             dependencies: ["CuckooGenerator"],
-            path: "Generator/Plugin/PerModule"
+            path: "Generator/Plugin/Modular"
         ),
         // .plugin(
         //     name: "CuckooPluginIndividualFiles",

--- a/README.md
+++ b/README.md
@@ -133,62 +133,48 @@ target = "Cuckoonator"
 
 #### For CuckooPluginModular
 
-When using `CuckooPluginModular`, the plugin automatically detects source modules from your test target's dependencies and generates a dedicated mock file for each one (`GeneratedMocks_<ModuleName>.swift`). It supports compound module names (`TARGET/MODULE`) in `Cuckoofile.toml` so that different test targets can customize mock generation for shared dependencies.
+`CuckooPluginSingleFile` puts all mocks into a single `GeneratedMocks.swift` file in derived data. In a Swift Package with multiple targets this is problematic because each test target compiles independently and may not have visibility into types from unrelated modules. Use `CuckooPluginModular` instead: it inspects your test target's dependencies and runs the generator once per dependency module, producing a separate `GeneratedMocks_<ModuleName>.swift` for each.
+
+A `Cuckoofile.toml` entry is required for each module you want to generate mocks for. The plugin looks up the test target's own name (e.g. `[modules.TargetATests]`), letting you specify which source files to mock and which imports to add. Modules without a matching entry produce an empty file and no mocks.
 
 **Example `Cuckoofile.toml` for modular projects:**
 
 ```toml
-# CoreModule mocks
-[modules.CoreModuleTests]
+# TargetA mocks
+[modules.TargetATests]
 imports = ["Foundation"]
-testableImports = ["CoreModule"]
+testableImports = ["TargetA"] #ProtocolA is internal to TargetA
 sources = [
-    "Sources/CoreModule/ServiceProtocol.swift"
+    "Sources/TargetA/InternalProtocolA.swift"
 ]
 
-# NetworkAPI module mocks
-[modules.FirstNetworkAPITests]
-imports = ["Foundation"]
-testableImports = ["FirstNetworkAPI"]
+# AggregationTarget mocks - demonstrates multiple testableImports
+[modules.AggregationTargetTests]
+imports = ["Foundation", "TargetA", "TargetB"]
 sources = [
-    "Sources/FirstNetworkAPI/Generated/Client.swift"
-]
-
-# SecondNetworkAPI module mocks
-[modules.SecondNetworkAPITests]
-imports = ["Foundation"]
-testableImports = ["SecondNetworkAPI"]
-sources = [
-    "Sources/SecondNetworkAPI/Generated/Client.swift"
-]
-
-# FeatureModule mocks - demonstrates multiple testableImports
-[modules.FeatureModuleTests]
-imports = ["Foundation"]
-testableImports = ["FirstNetworkAPI", "SecondNetworkAPI"]
-sources = [
-    "Sources/FirstNetworkAPI/FirstNetworkAPI.swift",
-    "Sources/SecondNetworkAPI/SecondNetworkAPI.swift"
+    "Sources/TargetA/ProtocolA.swift",
+    "Sources/TargetB/ProtocolB.swift",
 ]
 ```
 
-**Note:** The modules specified in `testableImports` must be added as dependencies of your test target in `Package.swift`. For example:
+`Package.swift`:
 
 ```swift
 .testTarget(
-    name: "CoreModuleTests",
-    dependencies: ["CoreModule", "Cuckoo"]
+    name: "TargetATests",
+    dependencies: ["TargetA", "Cuckoo"],
+    plugins: [
+        .plugin(name: "CuckooPluginModular", package: "Cuckoo"),
+    ]
 ),
 .testTarget(
-    name: "FeatureModuleTests",
-    dependencies: ["FirstNetworkAPI", "SecondNetworkAPI", "Cuckoo"]
+    name: "AggregationTargetTests",
+    dependencies: ["AggregationTarget", "Cuckoo"],
+    plugins: [
+        .plugin(name: "CuckooPluginModular", package: "Cuckoo"),
+    ]
 )
 ```
-
-This approach is essential when:
-- **Multiple modules define protocols/types with identical names** (e.g., both `ModuleA` and `ModuleB` have a `ServiceProtocol`)
-- Different test targets need different subsets of mocks from the same module
-- You want to organize and namespace mocks by test target for clarity
 
 ### 3. Usage
 Usage of Cuckoo is similar to [Mockito](http://mockito.org/) and [Hamcrest](http://hamcrest.org/). However, there are some differences and limitations caused by generating the mocks and Swift language itself. List of all the supported features can be found below. You can find complete examples in [tests](Tests).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ URL: `https://github.com/Brightify/Cuckoo.git`
 
 When you're all set, go to your test target's Build Phases and add plug-in `CuckooPluginSingleFile` to the **Run Build Tool Plug-ins**.
 
+Alternatively, if your project has multiple modules and you want to generate separate mock files per dependency, use `CuckooPluginModular` instead. This plugin automatically detects source modules from your test target's dependencies and generates a dedicated mock file for each one (`GeneratedMocks_<ModuleName>.swift`). See [section 2](#2-cuckoofile-customization) for configuration details.
+
 #### CocoaPods
 Cuckoo runtime is available through [CocoaPods](http://cocoapods.org). To install it, simply add the following line to your **test target** in your Podfile:
 
@@ -87,7 +89,9 @@ Note: All paths in the Run script must be absolute. Variable `PROJECT_DIR` autom
 **Remember to include paths to inherited Classes and Protocols for mocking/stubbing parent and grandparents.**
 
 ### 2. Cuckoofile customization
-At the root of your project, create `Cuckoofile.toml` configuration file:
+At the root of your project, create `Cuckoofile.toml` configuration file.
+
+#### For CuckooPluginSingleFile
 
 ```toml
 # You can define a fallback output for all modules that don't define their own.
@@ -126,6 +130,65 @@ target = "Cuckoonator"
 [modules.AnotherProject]
 # ...
 ```
+
+#### For CuckooPluginModular
+
+When using `CuckooPluginModular`, the plugin automatically detects source modules from your test target's dependencies and generates a dedicated mock file for each one (`GeneratedMocks_<ModuleName>.swift`). It supports compound module names (`TARGET/MODULE`) in `Cuckoofile.toml` so that different test targets can customize mock generation for shared dependencies.
+
+**Example `Cuckoofile.toml` for modular projects:**
+
+```toml
+# CoreModule mocks
+[modules.CoreModuleTests]
+imports = ["Foundation"]
+testableImports = ["CoreModule"]
+sources = [
+    "Sources/CoreModule/ServiceProtocol.swift"
+]
+
+# NetworkAPI module mocks
+[modules.FirstNetworkAPITests]
+imports = ["Foundation"]
+testableImports = ["FirstNetworkAPI"]
+sources = [
+    "Sources/FirstNetworkAPI/Generated/Client.swift"
+]
+
+# SecondNetworkAPI module mocks
+[modules.SecondNetworkAPITests]
+imports = ["Foundation"]
+testableImports = ["SecondNetworkAPI"]
+sources = [
+    "Sources/SecondNetworkAPI/Generated/Client.swift"
+]
+
+# FeatureModule mocks - demonstrates multiple testableImports
+[modules.FeatureModuleTests]
+imports = ["Foundation"]
+testableImports = ["FirstNetworkAPI", "SecondNetworkAPI"]
+sources = [
+    "Sources/FirstNetworkAPI/FirstNetworkAPI.swift",
+    "Sources/SecondNetworkAPI/SecondNetworkAPI.swift"
+]
+```
+
+**Note:** The modules specified in `testableImports` must be added as dependencies of your test target in `Package.swift`. For example:
+
+```swift
+.testTarget(
+    name: "CoreModuleTests",
+    dependencies: ["CoreModule", "Cuckoo"]
+),
+.testTarget(
+    name: "FeatureModuleTests",
+    dependencies: ["FirstNetworkAPI", "SecondNetworkAPI", "Cuckoo"]
+)
+```
+
+This approach is essential when:
+- **Multiple modules define protocols/types with identical names** (e.g., both `ModuleA` and `ModuleB` have a `ServiceProtocol`)
+- Different test targets need different subsets of mocks from the same module
+- You want to organize and namespace mocks by test target for clarity
 
 ### 3. Usage
 Usage of Cuckoo is similar to [Mockito](http://mockito.org/) and [Hamcrest](http://hamcrest.org/). However, there are some differences and limitations caused by generating the mocks and Swift language itself. List of all the supported features can be found below. You can find complete examples in [tests](Tests).


### PR DESCRIPTION
### Summary
Adds a new `CuckooPluginModular` build tool plugin that generates separate mock files per module dependency, improving modularity for multi-target Swift Packages.

Related issue: https://github.com/Brightify/Cuckoo/issues/555

### Motivation
The existing `CuckooPluginSingleFile` generates all mocks into a single `GeneratedMocks.swift` file in derived data. In a Swift Package with multiple targets, each test target compiles independently and may not have visibility into types from unrelated modules, making a single shared mock file problematic.

### Changes

#### New Plugin: CuckooPluginModular

- Located in `Generator/Plugin/Modular/`
- Inspects the test target's dependencies (excluding Cuckoo) and runs the generator once per dependency module
- Each module gets its own build command with `CUCKOO_MODULE_NAME` environment variable
- Generates one mock file per module: `GeneratedMocks_<ModuleName>.swift`
- Also emits a build command keyed by the test target's own name, aggregating all dependency sources — this allows `Cuckoofile.toml` to have a `[modules.<TestTargetName>]` entry to control which files are mocked and which imports are added
- A `Cuckoofile.toml` entry is required for each module; modules without a matching entry produce an empty file

### Usage

**Package.swift:**
```swift
.testTarget(
    name: "TargetATests",
    dependencies: ["TargetA", "Cuckoo"],
    plugins: [
        .plugin(name: "CuckooPluginModular", package: "Cuckoo"),
    ]
),
.testTarget(
    name: "AggregationTargetTests",
    dependencies: ["AggregationTarget", "Cuckoo"],
    plugins: [
        .plugin(name: "CuckooPluginModular", package: "Cuckoo"),
    ]
)
```

**Cuckoofile.toml:**
```toml
# TargetA mocks
[modules.TargetATests]
imports = ["Foundation"]
testableImports = ["TargetA"]
sources = [
    "Sources/TargetA/InternalProtocolA.swift"
]

# AggregationTarget mocks - multiple imports
[modules.AggregationTargetTests]
imports = ["Foundation", "TargetA", "TargetB"]
sources = [
    "Sources/TargetA/ProtocolA.swift",
    "Sources/TargetB/ProtocolB.swift",
]
```

### Breaking Changes
None. All changes are backward compatible with existing plugins and configurations.
