### PR TITLE
Support #if/#elseif/#endif conditional compilation in mock generation

### DIFF
--- a/Generator/Project.swift
+++ b/Generator/Project.swift
@@ -14,6 +14,7 @@ let target = Target.target(
         "Stencil",
         "SwiftSyntax",
         "SwiftParser",
+        "SwiftIfConfig",
         "ArgumentParser",
         "TOMLKit",
         "XcodeProj",

--- a/Generator/Sources/CLI/Generator.swift
+++ b/Generator/Sources/CLI/Generator.swift
@@ -32,10 +32,11 @@ final class Generator {
             .filter { $0.exists }
             .map(TextFile.init(path:))
 
+        let buildConfiguration = CuckooGeneratorBuildConfiguration(customConditions: module.buildConditions)
         let files: [FileRepresentation] = await inputFiles.concurrentCompactMap { file in
             do {
                 log(.verbose, message: "Processing file: \(file.path)")
-                let crawler = try Crawler.crawl(url: file.path.url)
+                let crawler = try Crawler.crawl(url: file.path.url, buildConfiguration: buildConfiguration)
                 log(.verbose, message: "Successfully processed file: \(file.path)")
                 return FileRepresentation(file: file, imports: crawler.imports, tokens: crawler.tokens)
             } catch {

--- a/Generator/Sources/CLI/Module.swift
+++ b/Generator/Sources/CLI/Module.swift
@@ -15,6 +15,7 @@ final class Module: @unchecked Sendable {
     let filenameFormat: String?
     let options: Options
     let xcodeproj: Xcodeproj?
+    let buildConditions: Set<String>
 
     init(name: String, output: String?, configurationPath: Path, dto: DTO) throws {
         guard Module.overriddenOutput != nil || output != nil || dto.output != nil else {
@@ -39,6 +40,7 @@ final class Module: @unchecked Sendable {
             protocolsOnly: dto.options?.protocolsOnly ?? false,
             omitHeaders: dto.options?.omitHeaders ?? false
         )
+        self.buildConditions = Set(dto.buildConditions ?? [])
 
         if let xcodeproj = dto.xcodeproj {
             if let target = xcodeproj.target {
@@ -103,6 +105,7 @@ extension Module {
         let filenameFormat: String?
         let options: Options?
         let xcodeproj: Xcodeproj?
+        let buildConditions: [String]?
 
         struct Options: Decodable {
             let glob: Bool?
@@ -132,6 +135,7 @@ extension Module: CustomDebugStringConvertible {
             filenameFormat.map { "filename format: \($0.bold)" },
             "options:\(options.debugDescription.components(separatedBy: "\n").map { "\n\t- \($0)" }.joined())",
             xcodeproj.map { "xcodeproj:\($0.debugDescription.components(separatedBy: "\n").map { "\n\t- \($0)" }.joined())" },
+            buildConditions.isEmpty ? nil : "build conditions:\(buildConditions.sorted().map { "\n\t-\($0.bold)" }.joined())",
         ]
         .compactMap { $0 }
         .joined(separator: "\n")

--- a/Generator/Sources/Internal/Crawlers/Crawler.swift
+++ b/Generator/Sources/Internal/Crawlers/Crawler.swift
@@ -1,9 +1,10 @@
 import Foundation
 import SwiftSyntax
 import SwiftParser
+import SwiftIfConfig
 
 final class Crawler: SyntaxVisitor {
-    static func crawl(url: URL) throws -> Crawler {
+    static func crawl(url: URL, buildConfiguration: CuckooGeneratorBuildConfiguration = .init(customConditions: [])) throws -> Crawler {
         let file = try String(contentsOf: url)
         let syntaxTree = Parser.parse(source: file)
         #if DEBUG
@@ -11,7 +12,7 @@ final class Crawler: SyntaxVisitor {
         // The `testString` is at the bottom of this file.
 //        let syntaxTree = Parser.parse(source: testString)
         #endif
-        let crawler = Self(container: nil, url: url)
+        let crawler = Self(container: nil, url: url, buildConfiguration: buildConfiguration)
         crawler.walk(syntaxTree)
         return crawler
     }
@@ -22,10 +23,12 @@ final class Crawler: SyntaxVisitor {
     private var container: Reference<Token>?
 
     private let url: URL
+    private let buildConfiguration: CuckooGeneratorBuildConfiguration
 
-    private init(container: Reference<Token>?, url: URL) {
+    private init(container: Reference<Token>?, url: URL, buildConfiguration: CuckooGeneratorBuildConfiguration) {
         self.container = container
         self.url = url
+        self.buildConfiguration = buildConfiguration
 
         super.init(viewMode: .sourceAccurate)
     }
@@ -61,7 +64,7 @@ final class Crawler: SyntaxVisitor {
 
         guard token.accessibility.isAccessible else { return .skipChildren }
 
-        let crawler = Crawler(container: Reference(token), url: url)
+        let crawler = Crawler(container: Reference(token), url: url, buildConfiguration: buildConfiguration)
         crawler.walk(members: node.memberBlock)
         token.members = crawler.tokens
         tokens.append(token)
@@ -85,7 +88,7 @@ final class Crawler: SyntaxVisitor {
 
         guard token.accessibility.isAccessible else { return .skipChildren }
 
-        let crawler = Crawler(container: Reference(token), url: url)
+        let crawler = Crawler(container: Reference(token), url: url, buildConfiguration: buildConfiguration)
         crawler.walk(members: node.memberBlock)
         token.members = crawler.tokens
         tokens.append(token)
@@ -105,7 +108,7 @@ final class Crawler: SyntaxVisitor {
 
         guard token.accessibility.isAccessible else { return .skipChildren }
 
-        let crawler = Crawler(container: Reference(token), url: url)
+        let crawler = Crawler(container: Reference(token), url: url, buildConfiguration: buildConfiguration)
         crawler.walk(members: node.memberBlock)
         token.members = crawler.tokens
         tokens.append(token)
@@ -125,7 +128,7 @@ final class Crawler: SyntaxVisitor {
 
         guard token.accessibility.isAccessible else { return .skipChildren }
 
-        let crawler = Crawler(container: Reference(token), url: url)
+        let crawler = Crawler(container: Reference(token), url: url, buildConfiguration: buildConfiguration)
         crawler.walk(members: node.memberBlock)
         token.members = crawler.tokens
         tokens.append(token)
@@ -145,7 +148,7 @@ final class Crawler: SyntaxVisitor {
 
         guard token.accessibility.isAccessible else { return .skipChildren }
 
-        let crawler = Crawler(container: Reference(token), url: url)
+        let crawler = Crawler(container: Reference(token), url: url, buildConfiguration: buildConfiguration)
         crawler.walk(members: node.memberBlock)
         token.members = crawler.tokens
         tokens.append(token)
@@ -178,8 +181,21 @@ final class Crawler: SyntaxVisitor {
     }
 
     override func visit(_ node: IfConfigDeclSyntax) -> SyntaxVisitorContinueKind {
-        // TODO: Implement #if functionality.
-        return .visitChildren
+        let (activeClause, _) = node.activeClause(in: buildConfiguration)
+        guard let elements = activeClause?.elements else { return .skipChildren }
+        switch elements {
+        case .decls(let memberList):
+            for member in memberList {
+                walk(member)
+            }
+        case .statements(let stmtList):
+            for stmt in stmtList {
+                walk(stmt)
+            }
+        default:
+            break
+        }
+        return .skipChildren
     }
 
     override func visit(_ node: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {

--- a/Generator/Sources/Internal/Crawlers/CuckooGeneratorBuildConfiguration.swift
+++ b/Generator/Sources/Internal/Crawlers/CuckooGeneratorBuildConfiguration.swift
@@ -1,0 +1,55 @@
+import SwiftIfConfig
+import SwiftSyntax
+
+/// A BuildConfiguration implementation for the Cuckoo generator that evaluates `#if` conditions
+/// based on user-supplied custom conditions and sensible defaults for known platform/compiler queries.
+struct CuckooGeneratorBuildConfiguration: BuildConfiguration {
+    /// Custom conditions set via `-D` flags (e.g. `-D DEBUG`).
+    let customConditions: Set<String>
+
+    func isCustomConditionSet(name: String) throws -> Bool {
+        customConditions.contains(name)
+    }
+
+    func hasFeature(name: String) throws -> Bool {
+        false
+    }
+
+    func hasAttribute(name: String) throws -> Bool {
+        false
+    }
+
+    func canImport(importPath: [(TokenSyntax, String)], version: CanImportVersion) throws -> Bool {
+        false
+    }
+
+    func isActiveTargetOS(name: String) throws -> Bool {
+        false
+    }
+
+    func isActiveTargetArchitecture(name: String) throws -> Bool {
+        false
+    }
+
+    func isActiveTargetEnvironment(name: String) throws -> Bool {
+        false
+    }
+
+    func isActiveTargetRuntime(name: String) throws -> Bool {
+        false
+    }
+
+    func isActiveTargetPointerAuthentication(name: String) throws -> Bool {
+        false
+    }
+
+    var targetPointerBitWidth: Int { 64 }
+
+    var targetAtomicBitWidths: [Int] { [32, 64] }
+
+    var endianness: Endianness { .little }
+
+    var languageVersion: VersionTuple { VersionTuple(6, 0) }
+
+    var compilerVersion: VersionTuple { VersionTuple(6, 0) }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -58,6 +58,7 @@ let package = Package(
                 // .product(name: "SwiftFormat", package: "swift-format"),
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
                 .product(name: "SwiftParser", package: "swift-syntax"),
+                .product(name: "SwiftIfConfig", package: "swift-syntax"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "TOMLKit", package: "TOMLKit"),
                 .product(name: "XcodeProj", package: "XcodeProj"),


### PR DESCRIPTION
## Summary

Fixes #471 — conditional compilation blocks (`#if`/`#elseif`/`#else`/`#endif`) in protocols and classes are now correctly handled by the mock generator.

- Uses **`SwiftIfConfig`** (already included in the `swift-syntax` package dependency) to evaluate `#if` conditions against a configurable build configuration.
- Replaces the `// TODO: Implement #if functionality.` stub in `Crawler.visit(_:IfConfigDeclSyntax)` with proper active-clause evaluation — only the active branch's members are crawled.
- Adds a new `build_conditions` field to `Cuckoofile.toml` module configuration so users can declare which custom conditions are active during mock generation:

```toml
[modules.MyModule]
sources = ["Sources/**/*.swift"]
output = "GeneratedMocks.swift"
build_conditions = ["DEBUG", "MY_FEATURE_FLAG"]
```

- Platform/OS/arch/runtime conditions that can't be known at generation time (e.g. `os(iOS)`) default to **false** (inactive), matching the safest behaviour — only explicitly declared conditions are active.

## Changes

| File | Change |
|------|--------|
| `Package.swift` | Add `SwiftIfConfig` product to `CuckooGenerator` target dependencies |
| `Generator/Project.swift` | Mirror the same dependency for the Tuist project |
| `Generator/Sources/Internal/Crawlers/CuckooGeneratorBuildConfiguration.swift` | New — implements `BuildConfiguration` protocol for use with `SwiftIfConfig` |
| `Generator/Sources/Internal/Crawlers/Crawler.swift` | Use `SwiftIfConfig` to evaluate `#if` conditions; propagate `buildConfiguration` through sub-crawlers |
| `Generator/Sources/CLI/Module.swift` | Add `buildConditions: Set<String>` property and `build_conditions` TOML key |
| `Generator/Sources/CLI/Generator.swift` | Construct `CuckooGeneratorBuildConfiguration` from module's `buildConditions` and pass to `Crawler.crawl` |

## Test plan

- [ ] Protocol with `#if MY_FLAG` block: when `MY_FLAG` is in `build_conditions`, the flagged methods appear in the generated mock; when absent, they are excluded
- [ ] `#elseif` and `#else` branches are resolved to the correct active clause
- [ ] Nested `#if` blocks inside `#if` blocks work correctly
- [ ] Platform conditions like `#if os(iOS)` produce no members by default (not crashing or including both branches)
- [ ] Existing mocks without any `#if` blocks are unaffected