### PR TITLE
feat: add configurable mockPrefix to Cuckoofile.toml

### DIFF
--- a/Cuckoofile.toml
+++ b/Cuckoofile.toml
@@ -1,5 +1,10 @@
 # output = "Tests/Swift/Generated/GeneratedMocks.swift"
 
+# Custom prefix for generated mock classes (default: "Mock").
+# When set, mock classes will be named <prefix><TypeName> instead of Mock<TypeName>.
+# Example: mockPrefix = "Fake" generates FakeGreeter instead of MockGreeter.
+# mockPrefix = "Mock"
+
 [modules.Cuckoo]
 imports = ["Foundation"]
 testableImports = ["Cuckoo"]

--- a/Generator/Sources/CLI/GenerateCommand.swift
+++ b/Generator/Sources/CLI/GenerateCommand.swift
@@ -154,6 +154,11 @@ struct GenerateCommand: AsyncParsableCommand {
                 } else {
                     errorMessages.append("Multiple global `output` parameters. Behavior is undefined.")
                 }
+            case "mockPrefix":
+                if let prefix = value.string {
+                    Module.mockPrefix = prefix
+                    log(.verbose, message: "Global mock prefix:", prefix)
+                }
             case "modules":
                 guard let modulesTable = value.table else {
                     throw GenerateError.modulesMustBeTable

--- a/Generator/Sources/CLI/Module.swift
+++ b/Generator/Sources/CLI/Module.swift
@@ -3,6 +3,7 @@ import FileKit
 
 final class Module: @unchecked Sendable {
     nonisolated(unsafe) static var overriddenOutput: String?
+    nonisolated(unsafe) static var mockPrefix: String = "Mock"
 
     let name: String
     let imports: [String]
@@ -37,7 +38,8 @@ final class Module: @unchecked Sendable {
             keepDocumentation: dto.options?.keepDocumentation ?? true,
             enableInheritance: dto.options?.enableInheritance ?? true,
             protocolsOnly: dto.options?.protocolsOnly ?? false,
-            omitHeaders: dto.options?.omitHeaders ?? false
+            omitHeaders: dto.options?.omitHeaders ?? false,
+            mockPrefix: dto.options?.mockPrefix ?? Module.mockPrefix
         )
 
         if let xcodeproj = dto.xcodeproj {
@@ -66,6 +68,7 @@ final class Module: @unchecked Sendable {
         let enableInheritance: Bool
         let protocolsOnly: Bool
         let omitHeaders: Bool
+        let mockPrefix: String
     }
 
     struct Xcodeproj {
@@ -110,6 +113,7 @@ extension Module {
             let enableInheritance: Bool?
             let protocolsOnly: Bool?
             let omitHeaders: Bool?
+            let mockPrefix: String?
         }
 
         struct Xcodeproj: Decodable {
@@ -146,6 +150,7 @@ extension Module.Options: CustomDebugStringConvertible {
             "enable inheritance: \(String(enableInheritance).bold)",
             "protocols only: \(String(protocolsOnly).bold)",
             "omit headers: \(String(omitHeaders).bold)",
+            "mock prefix: \(mockPrefix.bold)",
         ]
         .compactMap { $0 }
         .joined(separator: "\n")

--- a/Generator/Sources/Internal/Tokens/Capabilities/HasName.swift
+++ b/Generator/Sources/Internal/Tokens/Capabilities/HasName.swift
@@ -4,7 +4,7 @@ protocol HasName: Token {
 
 extension HasName {
     var mockName: String {
-        "Mock\(name)"
+        "\(Module.mockPrefix)\(name)"
     }
 
     var fullyQualifiedName: String {


### PR DESCRIPTION
## Summary

Add a global `mockPrefix` option to `Cuckoofile.toml` that allows customizing the prefix of generated mock class names.

Closes #564

## Changes

- **Module.swift**: Added `mockPrefix` to `DTO.Options` and `Options` structs
- **HasName.swift**: Changed `mockName` to use `Module.mockPrefix` instead of hardcoded `"Mock"`
- **GenerateCommand.swift**: Added parsing for global `mockPrefix` TOML key
- **Cuckoofile.toml**: Added documented `mockPrefix` option

## Usage

```toml
# Global prefix (default: "Mock")
mockPrefix = "Fake"

[modules.MyProject]
output = "GeneratedMocks.swift"
```

This generates `FakeGreeter` instead of `MockGreeter`.

## Backward Compatibility

- Default value is `"Mock"`, preserving existing behavior
- No changes to generated output when `mockPrefix` is not specified