### PR TITLE
Fix generator version mismatch

### DIFF
--- a/Generator/Sources/CLI/Version.swift
+++ b/Generator/Sources/CLI/Version.swift
@@ -1,1 +1,1 @@
-let version = "2.0.10"
+let version = "2.4.0"

--- a/Generator/Tests/VersionTest.swift
+++ b/Generator/Tests/VersionTest.swift
@@ -1,0 +1,17 @@
+import Foundation
+import XCTest
+
+final class VersionTest: XCTestCase {
+    func testGeneratorVersionMatchesLibraryVersion() throws {
+        let repositoryURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let libraryVersion = try String(
+            contentsOf: repositoryURL.appendingPathComponent("version"),
+            encoding: .utf8
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        XCTAssertEqual(version, libraryVersion)
+    }
+}


### PR DESCRIPTION
## Summary

- update the Cuckoo generator version from `2.0.10` to `2.4.0`
- add a regression test that keeps the generator version aligned with the root `version` file

## Testing

- verified the generator version matches the root `version` file
- `git diff --check`
- macOS Swift/Xcode tests were not run locally because this environment is Windows

Closes #601
